### PR TITLE
fix: Primeira letra maiúscula em Sou Professor

### DIFF
--- a/src/screens/registerType/components/SelectRegisterType/index.tsx
+++ b/src/screens/registerType/components/SelectRegisterType/index.tsx
@@ -34,7 +34,7 @@ const SelectRegisterType = () => {
           id={testId.typeRegister.iAmProfessorButton}
           onClick={handleClickProfessor}
         >
-          Sou professor
+          Sou Professor
         </ProfessorButton>
         <StudentButton
           id={testId.typeRegister.iAmStudentButton}


### PR DESCRIPTION
# Descrição

O texto no botão de professor na tela de registro estava "Sou professor" mas deveria ser "Sou Professor".

# Setup

- `yarn start`

# Cenários

## 1. Texto do botão de professor no login

- [ ] Na página de login, clique no botão de cadastro.
- [ ] Na tela de escolher tipo de usuário, verifique se o botão de professor está com o texto "Sou Professor".