### PR TITLE
fix: Conserta largura do login no mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "jest --verbose --passWithNoTests --silent",
+    "test": "jest --verbose --passWithNoTests --silent --maxWorkers=50%",
     "eject": "react-scripts eject",
     "lint": "npx eslint ./src && echo \"> No lint errors found in src/.\"",
     "lint:commit": "npx --no-install commitlint --edit && echo \"> No errors found in commit messages.\"",
@@ -76,7 +76,7 @@
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.31.10",
     "husky": "^8.0.0",
-    "jest": "^29.1.2",
+    "jest": "^29.3.1",
     "jest-canvas-mock": "^2.4.0",
     "jest-environment-jsdom": "^29.1.2",
     "prettier": "^2.7.1",

--- a/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
+++ b/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -105,7 +105,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >
@@ -442,7 +442,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -458,7 +458,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >
@@ -803,7 +803,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -819,7 +819,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >
@@ -1165,7 +1165,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -1181,7 +1181,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >
@@ -1532,7 +1532,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -1548,7 +1548,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >
@@ -1918,7 +1918,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
       className="sc-idXgbr MuiBox-root css-wkpw2c"
     >
       <div
-        className="sc-pyfCe MuiBox-root css-1b6n4o1"
+        className="sc-pyfCe daZzEw MuiBox-root css-1b6n4o1"
       >
         <div
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
@@ -1934,7 +1934,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
             Insira suas credenciais abaixo para continuar
           </p>
           <form
-            className="sc-kDvujY kpgBAx"
+            className="sc-kDvujY dgdtEP"
             id="login-form"
             onSubmit={[MockFunction]}
           >

--- a/src/screens/login/components/FormLogin/styles.ts
+++ b/src/screens/login/components/FormLogin/styles.ts
@@ -11,7 +11,11 @@ export const Container = styled(Box).attrs({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'space-between',
-})``;
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+  }
+`;
 
 export const ContainerUp = styled(Box).attrs({
   display: 'flex',
@@ -24,6 +28,7 @@ export const StyledForm = styled.form`
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100% !important;
 `;
 
 export const ContainerLogin = styled(Box).attrs({


### PR DESCRIPTION
# Descrição

- Aumenta largura do formulário de login na versão mobile.
- Acelera testes com `--maxWorkers=50%` ([Referência](https://dev.to/vantanev/make-your-jest-tests-up-to-20-faster-by-changing-a-single-setting-i36))

# Setup

- [ ] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Tela de login no mobile

- [ ] Acesse a tela de login na versão para celular.
- [ ] Verifique se o formulário está maior que antes

| Antes  | Depois |
| ------------- | ------------- |
| ![Captura de tela de 2022-11-12 10-56-47](https://user-images.githubusercontent.com/26875510/201480147-b1e24446-b326-4ad0-858b-bac36975207f.png) | ![Captura de tela de 2022-11-12 10-56-53](https://user-images.githubusercontent.com/26875510/201480158-2b793555-6ac4-476b-b487-c9b9603e2c09.png) |