### PR TITLE
fix: Conserta a cor do link no login

### DIFF
--- a/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
+++ b/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
@@ -305,6 +305,11 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
@@ -663,6 +668,11 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
@@ -1025,6 +1035,11 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
@@ -1392,6 +1407,11 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
@@ -1781,6 +1801,11 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
@@ -2134,6 +2159,11 @@ exports[`Test Login screen snapshot tests should render screen with password sho
             className=""
             href="/register"
             onClick={[Function]}
+            style={
+              {
+                "textDecorationColor": "#2D2D2C",
+              }
+            }
           >
             <p
               className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"

--- a/src/screens/login/components/FormLogin/index.tsx
+++ b/src/screens/login/components/FormLogin/index.tsx
@@ -15,6 +15,7 @@ import { NavLink } from 'react-router-dom';
 import { TextField } from '../../../../components/textField';
 import { SCREENS } from '../../../../utils/screens';
 import testId from '../../../../utils/testId';
+import theme from '../../../../utils/theme';
 import useLogin from '../../hooks/useLogin';
 import {
   Container,
@@ -130,7 +131,10 @@ const FormLogin = () => {
 
       <ContainerBottom>
         <Typography align="center">Ainda não tem uma conta?&nbsp;</Typography>
-        <NavLink to={SCREENS.REGISTER}>
+        <NavLink
+          style={{ textDecorationColor: theme.palette.secondary.main }}
+          to={SCREENS.REGISTER}
+        >
           <Typography color={'secondary'}>Cadastre-se</Typography>
         </NavLink>
       </ContainerBottom>


### PR DESCRIPTION
# Descrição

- Seta a cor do sublinhado do link de cadastro no login para ser sempre preto.

# Em casos de bugfix

- Qual foi a causa do bug?
  - Quando o usuário já clicou no link de cadastro, o sublinhado dele estava ficando azul.
- O que foi feito para corrigi-lo?
  - Seta a cor do sublinhado do link de cadastro no login para ser sempre preto.

# Cenários

Esse problema só acontecem em dev e staging, então não é possível testar localmente.
