### PR TITLE
fix: Conserta letra minúscula no placeholder

### DIFF
--- a/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
+++ b/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
@@ -121,7 +121,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="Código de confirmação"
+            placeholder="Código de Confirmação"
             type="text"
             value=""
           />
@@ -368,7 +368,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="Código de confirmação"
+            placeholder="Código de Confirmação"
             type="text"
             value=""
           />
@@ -730,7 +730,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="Código de confirmação"
+            placeholder="Código de Confirmação"
             type="text"
             value="123456"
           />
@@ -1060,7 +1060,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            placeholder="Código de confirmação"
+            placeholder="Código de Confirmação"
             type="text"
             value=""
           />

--- a/src/screens/codeVerification/styles.ts
+++ b/src/screens/codeVerification/styles.ts
@@ -17,7 +17,7 @@ export const Container = styled(Box).attrs({
 export const CodeTextField = styled(TextField).attrs({
   type: 'text',
   name: 'code',
-  placeholder: 'Código de confirmação',
+  placeholder: 'Código de Confirmação',
   inputProps: { maxLength: 6 },
 })`
   width: 100% !important;


### PR DESCRIPTION
# Descrição

Conserta o placeholder do campo de confirmação de código:
  - Antes: "Código de confirmação"
  - Depois: "Código de Confirmação"

# Setup

- [ ] `yarn start`
- [ ] Acesse a rota `/code-verification`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Placeholder do código de verificação

- [ ] Verifique se o placeholder do campo de informar o código de verificação está com o texto correto:

| Antes  | Depois |
| ------------- | ------------- |
| ![Captura de Tela 2022-11-19 às 12 52 59](https://user-images.githubusercontent.com/26875510/202862379-51822279-5dc0-4584-965d-d8118917cbff.png) | ![Captura de Tela 2022-11-19 às 12 54 11](https://user-images.githubusercontent.com/26875510/202862391-46991b73-3e1d-4d74-8bee-e55a79ff779b.png) |

  - OBS.: Ignore a mensagem de erro.