### PR TITLE
feat: Adiciona tela final de disciplinas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import MonitorRequests from './screens/monitorRequests';
 import RegisterProfessor from './screens/registerProfessor';
 import RegisterStudent from './screens/registerStudent';
 import Register from './screens/registerType';
+import SubjectDetails from './screens/subjectDetails';
 import Subjects from './screens/subjects';
 import { SCREENS } from './utils/screens';
 import theme from './utils/theme';
@@ -28,6 +29,7 @@ const App: React.FC = () => {
             element={<RegisterProfessor />}
           />
           <Route path={SCREENS.CREATE_STUDENT} element={<RegisterStudent />} />
+          <Route path={SCREENS.SUBJECT_DETAILS} element={<SubjectDetails />} />
           <Route path={SCREENS.SUBJECTS} element={<Subjects />} />
           <Route path={SCREENS.CALENDAR} element={<Calendar />} />
           <Route

--- a/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
+++ b/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
@@ -89,12 +89,12 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
         />
       </div>
       <h3
-        className="MuiTypography-root MuiTypography-h3 css-1w7645j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h3 css-h8fymg-MuiTypography-root"
       >
         Quase lá!
       </h3>
       <p
-        className="MuiTypography-root MuiTypography-body1 css-5fhr9f-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-body1 css-kilq1v-MuiTypography-root"
       >
         Te enviamos um código de confirmação de e-mail. Para concluir seu cadastro, digite o código recebido abaixo.
       </p>
@@ -108,7 +108,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-v9i4p-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -336,12 +336,12 @@ exports[`Test Code Verification screen snapshot tests should render code generat
         />
       </div>
       <h3
-        className="MuiTypography-root MuiTypography-h3 css-1w7645j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h3 css-h8fymg-MuiTypography-root"
       >
         Quase lá!
       </h3>
       <p
-        className="MuiTypography-root MuiTypography-body1 css-5fhr9f-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-body1 css-kilq1v-MuiTypography-root"
       >
         Te enviamos um código de confirmação de e-mail. Para concluir seu cadastro, digite o código recebido abaixo.
       </p>
@@ -355,7 +355,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-v9i4p-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -553,12 +553,12 @@ exports[`Test Code Verification screen snapshot tests should render code verifie
         />
       </div>
       <h3
-        className="MuiTypography-root MuiTypography-h3 css-1w7645j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h3 css-h8fymg-MuiTypography-root"
       >
         Muito bem!
       </h3>
       <p
-        className="MuiTypography-root MuiTypography-body1 css-5fhr9f-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-body1 css-kilq1v-MuiTypography-root"
       >
         Agora que seu cadastro foi concluído você poderá aproveitar para solicitar ajuda dos monitores sempre que precisar.
       </p>
@@ -698,12 +698,12 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
         />
       </div>
       <h3
-        className="MuiTypography-root MuiTypography-h3 css-1w7645j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h3 css-h8fymg-MuiTypography-root"
       >
         Quase lá!
       </h3>
       <p
-        className="MuiTypography-root MuiTypography-body1 css-5fhr9f-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-body1 css-kilq1v-MuiTypography-root"
       >
         Te enviamos um código de confirmação de e-mail. Para concluir seu cadastro, digite o código recebido abaixo.
       </p>
@@ -717,7 +717,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-v9i4p-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -1028,12 +1028,12 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
         />
       </div>
       <h3
-        className="MuiTypography-root MuiTypography-h3 css-1w7645j-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-h3 css-h8fymg-MuiTypography-root"
       >
         Quase lá!
       </h3>
       <p
-        className="MuiTypography-root MuiTypography-body1 css-5fhr9f-MuiTypography-root"
+        className="MuiTypography-root MuiTypography-body1 css-kilq1v-MuiTypography-root"
       >
         Te enviamos um código de confirmação de e-mail. Para concluir seu cadastro, digite o código recebido abaixo.
       </p>
@@ -1047,7 +1047,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-v9i4p-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input

--- a/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
+++ b/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
@@ -56,7 +56,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -95,12 +95,12 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -113,7 +113,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -169,7 +169,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -297,7 +297,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -312,7 +312,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>
@@ -414,7 +414,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -453,12 +453,12 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -471,7 +471,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -532,7 +532,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -660,7 +660,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -675,7 +675,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>
@@ -777,7 +777,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -819,12 +819,12 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -837,7 +837,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -893,7 +893,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1027,7 +1027,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -1042,7 +1042,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>
@@ -1144,7 +1144,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -1186,12 +1186,12 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -1204,7 +1204,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1260,7 +1260,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1399,7 +1399,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -1414,7 +1414,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>
@@ -1516,7 +1516,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -1558,12 +1558,12 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -1576,7 +1576,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1632,7 +1632,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1793,7 +1793,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -1808,7 +1808,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>
@@ -1910,7 +1910,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
           className="sc-fEXmlR ktuAEL MuiBox-root css-1ay9vb9"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 css-1jxod77-MuiTypography-root"
           >
             Não é cadastrado?
           </p>
@@ -1949,12 +1949,12 @@ exports[`Test Login screen snapshot tests should render screen with password sho
           className="sc-jrcTuL MuiBox-root css-wkpw2c"
         >
           <h3
-            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-ses0wv-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-h3 ForwardRef(Typography)-root-1 css-10jwzv0-MuiTypography-root"
           >
             Faça seu login
           </h3>
           <p
-            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-h4jzzx-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 ForwardRef(Typography)-root-2 css-1jxod77-MuiTypography-root"
           >
             Insira suas credenciais abaixo para continuar
           </p>
@@ -1967,7 +1967,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-1xv2y7e-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -2023,7 +2023,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1l7of66-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -2151,7 +2151,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
           className="sc-bqWxrE MuiBox-root css-1tqrsn5"
         >
           <p
-            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-5fhr9f-MuiTypography-root"
+            className="MuiTypography-root MuiTypography-body1 MuiTypography-alignCenter css-kilq1v-MuiTypography-root"
           >
             Ainda não tem uma conta? 
           </p>
@@ -2166,7 +2166,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
             }
           >
             <p
-              className="MuiTypography-root MuiTypography-body1 css-1i4c8mu-MuiTypography-root"
+              className="MuiTypography-root MuiTypography-body1 css-14zn9tq-MuiTypography-root"
             >
               Cadastre-se
             </p>

--- a/src/screens/subjectDetails/index.tsx
+++ b/src/screens/subjectDetails/index.tsx
@@ -1,0 +1,16 @@
+import { Typography } from '@mui/material';
+import { SidebarItemEnum } from '../../utils/constants';
+import ContainerWithSidebar from '../../components/containerWithSidebar';
+import { useParams } from 'react-router-dom';
+
+const SubjectDetails = () => {
+  const { id } = useParams();
+
+  return (
+    <ContainerWithSidebar selectedSidebarItem={SidebarItemEnum.SUBJECTS}>
+      <Typography variant="h3">[WIP] Detalhes da disciplina {id}</Typography>
+    </ContainerWithSidebar>
+  );
+};
+
+export default SubjectDetails;

--- a/src/screens/subjects/components/SubjectsList/index.tsx
+++ b/src/screens/subjects/components/SubjectsList/index.tsx
@@ -1,0 +1,86 @@
+import { CircularProgress, Pagination } from '@mui/material';
+import { TSubject } from '../../../../service/requests/useListSubjectsRequest/types';
+import SubjectsListItem from '../SubjectsListItem';
+import {
+  Container,
+  FallbackContainer,
+  FallbackTypography,
+  ListContainer,
+  PaginationContainer,
+  ProgressContainer,
+} from './styles';
+
+type Props = {
+  isLoading: boolean;
+  page: number;
+  totalPages: number;
+  subjects?: TSubject[];
+  userTypeId?: number;
+  handleAddProfessor(id: number): void;
+  handleChangePage(event: React.ChangeEvent<unknown>, page: number): void;
+  handleSubjectClick(id: number): void;
+  handleScheduleHelp(id: number): void;
+};
+
+const SubjectsList = ({
+  isLoading,
+  page,
+  totalPages,
+  subjects,
+  userTypeId,
+  handleAddProfessor,
+  handleChangePage,
+  handleScheduleHelp,
+  handleSubjectClick,
+}: Props) => {
+  if (isLoading || subjects === undefined) {
+    return (
+      <Container>
+        <ProgressContainer>
+          <CircularProgress color="primary" />
+        </ProgressContainer>
+      </Container>
+    );
+  }
+
+  if (subjects.length === 0) {
+    return (
+      <Container>
+        <FallbackContainer>
+          <FallbackTypography>
+            Ops... Parece que a disciplina que você procura não existe. Revise a
+            grafia e tente novamente.
+          </FallbackTypography>
+        </FallbackContainer>
+      </Container>
+    );
+  }
+
+  return (
+    <Container>
+      <ListContainer>
+        {subjects.map((subject) => (
+          <SubjectsListItem
+            key={subject.id}
+            subject={subject}
+            userTypeId={userTypeId}
+            handleAddProfessor={handleAddProfessor}
+            handleScheduleHelp={handleScheduleHelp}
+            handleSubjectClick={handleSubjectClick}
+          />
+        ))}
+      </ListContainer>
+
+      <PaginationContainer>
+        <Pagination
+          page={page}
+          onChange={handleChangePage}
+          count={totalPages}
+          color="primary"
+        />
+      </PaginationContainer>
+    </Container>
+  );
+};
+
+export default SubjectsList;

--- a/src/screens/subjects/components/SubjectsList/styles.ts
+++ b/src/screens/subjects/components/SubjectsList/styles.ts
@@ -1,0 +1,54 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../../../utils/theme';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+})``;
+
+export const ProgressContainer = styled(Box).attrs({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '40vh',
+})``;
+
+export const FallbackContainer = styled(Box).attrs({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '100%',
+  height: '10vh',
+})`
+  p {
+    color: ${theme.palette.grey[500]} !important;
+    text-align: center;
+  }
+`;
+
+export const FallbackTypography = styled(Typography).attrs({
+  variant: 'body1',
+  color: theme.palette.grey[500],
+  textAlign: 'center',
+})``;
+
+export const ListContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '16px',
+})``;
+
+export const PaginationContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  marginTop: '32px',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    margin: 32px 0 !important;
+  }
+`;

--- a/src/screens/subjects/components/SubjectsListItem/index.tsx
+++ b/src/screens/subjects/components/SubjectsListItem/index.tsx
@@ -1,0 +1,81 @@
+import { Add, CalendarMonthRounded } from '@mui/icons-material';
+import { CardContent } from '@mui/material';
+import React from 'react';
+import { TSubject } from '../../../../service/requests/useListSubjectsRequest/types';
+import { TypeUserEnum } from '../../../../utils/constants';
+import {
+  ActionButton,
+  ButtonContainer,
+  Container,
+  StyledCard,
+  SubjectName,
+} from './styles';
+
+type Props = {
+  subject: TSubject;
+  userTypeId?: number;
+  handleAddProfessor(id: number): void;
+  handleScheduleHelp(id: number): void;
+  handleSubjectClick(id: number): void;
+};
+
+const SubjectsListItem = ({
+  subject,
+  userTypeId,
+  handleAddProfessor,
+  handleScheduleHelp,
+  handleSubjectClick,
+}: Props) => {
+  const renderButton = () => {
+    if (userTypeId === TypeUserEnum.STUDENT) {
+      return (
+        <ButtonContainer>
+          <ActionButton
+            onClick={() => handleScheduleHelp(subject.id)}
+            startIcon={<CalendarMonthRounded />}
+          >
+            Ajuda
+          </ActionButton>
+        </ButtonContainer>
+      );
+    }
+
+    if (userTypeId === TypeUserEnum.COORDINATOR) {
+      return (
+        <ButtonContainer>
+          <ActionButton
+            onClick={() => handleAddProfessor(subject.id)}
+            startIcon={<Add />}
+          >
+            Professor
+          </ActionButton>
+        </ButtonContainer>
+      );
+    }
+
+    return <></>;
+  };
+
+  const handleCardClick = (e: React.MouseEvent) => {
+    const clickedElement = (e.target as HTMLTextAreaElement).localName;
+
+    // If user clicks on button or button icon, do nothing
+    if (clickedElement === 'div' || clickedElement === 'h6') {
+      return handleSubjectClick(subject.id);
+    }
+  };
+
+  return (
+    <StyledCard onClick={handleCardClick}>
+      <Container>
+        <CardContent>
+          <SubjectName>{subject.name}</SubjectName>
+        </CardContent>
+
+        {renderButton()}
+      </Container>
+    </StyledCard>
+  );
+};
+
+export default SubjectsListItem;

--- a/src/screens/subjects/components/SubjectsListItem/styles.ts
+++ b/src/screens/subjects/components/SubjectsListItem/styles.ts
@@ -1,0 +1,64 @@
+import { Card, CardActions, Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import { Button } from '../../../../components/button';
+import theme from '../../../../utils/theme';
+
+export const StyledCard = styled(Card).attrs({
+  width: '100%',
+})`
+  background-color: ${theme.palette.background.default} !important;
+  border-radius: 24px !important;
+  padding: 16px 24px;
+
+  :hover {
+    background-color: ${theme.palette.grey.A100} !important;
+    cursor: pointer;
+    transition: 0.8s;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    padding: 8px 16px !important;
+  }
+`;
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'space-between',
+  flexDirection: 'row',
+  alignItems: 'center',
+  width: '100%',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    flex-direction: column !important;
+  }
+`;
+
+export const ActionButton = styled(Button).attrs({
+  color: 'primary',
+  variant: 'outlined',
+  width: '140px',
+})`
+  :hover {
+    background-color: ${theme.palette.primary.main} !important;
+    color: white;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+  }
+`;
+
+export const ButtonContainer = styled(CardActions)`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+  }
+`;
+
+export const SubjectName = styled(Typography).attrs({
+  variant: 'h6',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    text-align: center !important;
+  }
+`;

--- a/src/screens/subjects/hooks/useSubjects.ts
+++ b/src/screens/subjects/hooks/useSubjects.ts
@@ -1,0 +1,88 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useListSubjectsRequest from '../../../service/requests/useListSubjectsRequest';
+import useGetLoggedUser from '../../../service/storage/getLoggedUser';
+import { SCREENS } from '../../../utils/screens';
+
+const useSubjects = () => {
+  const navigate = useNavigate();
+  const user = useGetLoggedUser();
+
+  const {
+    data: subjectsResponse,
+    isLoading: isLoadingSubjects,
+    error: subjectsError,
+    listSubjects,
+  } = useListSubjectsRequest();
+
+  const searchFieldElement = useRef<HTMLInputElement>();
+  const [page, setPage] = useState(1);
+
+  const totalPages = useMemo(
+    () => subjectsResponse?.meta.total_pages || 0,
+    [subjectsResponse]
+  );
+  const subjects = useMemo(
+    () => subjectsResponse?.data || [],
+    [subjectsResponse]
+  );
+
+  const handleSearch = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+
+    void listSubjects({ search: searchFieldElement.current?.value });
+  };
+
+  const handleChangePage = (
+    event: React.ChangeEvent<unknown>,
+    newPage: number
+  ) => {
+    if (newPage === page) return;
+
+    void listSubjects({ page: newPage });
+    setPage(newPage);
+  };
+
+  const handleSubjectClick = (subjectId: number) => {
+    navigate(SCREENS.SUBJECT_DETAILS.replace(':id', subjectId.toString()));
+  };
+
+  const handleAddProfessor = (subjectId: number) => {
+    // TODO - Adicionar modal
+    alert(`Add professor para a disciplina ${subjectId}`);
+  };
+
+  const handleScheduleHelp = (subjectId: number) => {
+    // TODO - Adicionar modal
+    alert(`Agendar ajuda na disciplina ${subjectId}`);
+  };
+
+  useEffect(() => {
+    if (!user) return navigate(SCREENS.LOGIN);
+
+    void listSubjects();
+  }, []);
+
+  useEffect(() => {
+    if (subjectsError) {
+      // TODO - Mudar para snackbar
+      alert(`Erro ao carregar disciplinas. Erro: ${subjectsError}`);
+    }
+  }, [subjectsError]);
+
+  return {
+    userTypeId: user?.type_user_id,
+    page,
+    totalPages,
+    subjects,
+    isLoadingSubjects,
+    searchFieldElement,
+    handleAddProfessor,
+    handleChangePage,
+    handleScheduleHelp,
+    handleSearch,
+    handleSubjectClick,
+  };
+};
+
+export default useSubjects;

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -1,11 +1,61 @@
-import { Typography } from '@mui/material';
+import { Search } from '@mui/icons-material';
+import { InputAdornment, Typography } from '@mui/material';
 import ContainerWithSidebar from '../../components/containerWithSidebar';
 import { SidebarItemEnum } from '../../utils/constants';
+import SubjectsList from './components/SubjectsList';
+import useSubjects from './hooks/useSubjects';
+import { Card, Container, SearchField } from './styles';
 
 const Subjects = () => {
+  const {
+    page,
+    subjects,
+    totalPages,
+    isLoadingSubjects,
+    searchFieldElement,
+    userTypeId,
+    handleAddProfessor,
+    handleChangePage,
+    handleScheduleHelp,
+    handleSearch,
+    handleSubjectClick,
+  } = useSubjects();
+
   return (
     <ContainerWithSidebar selectedSidebarItem={SidebarItemEnum.SUBJECTS}>
-      <Typography variant="h3">Disciplinas</Typography>
+      <Container>
+        <Card>
+          <Typography variant="h3">Disciplinas</Typography>
+          <Typography style={{ marginTop: '8px' }} variant="body1">
+            Clique na disciplina para exibir mais detalhes
+          </Typography>
+
+          <form onSubmit={handleSearch}>
+            <SearchField
+              inputRef={searchFieldElement}
+              placeholder="Buscar disciplina"
+              onChange={() => undefined}
+              startAdornment={
+                <InputAdornment position="start">
+                  <Search />
+                </InputAdornment>
+              }
+            />
+          </form>
+
+          <SubjectsList
+            page={page}
+            totalPages={totalPages}
+            subjects={subjects}
+            userTypeId={userTypeId}
+            isLoading={isLoadingSubjects}
+            handleAddProfessor={handleAddProfessor}
+            handleChangePage={handleChangePage}
+            handleScheduleHelp={handleScheduleHelp}
+            handleSubjectClick={handleSubjectClick}
+          />
+        </Card>
+      </Container>
     </ContainerWithSidebar>
   );
 };

--- a/src/screens/subjects/styles.ts
+++ b/src/screens/subjects/styles.ts
@@ -1,0 +1,56 @@
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import { TextField } from '../../components/textField';
+import theme from '../../utils/theme';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    padding: 0 16px !important;
+  }
+`;
+
+export const Card = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '32px',
+  maxWidth: '1128px',
+  margin: '24px',
+  backgroundColor: 'white',
+})`
+  border-radius: 24px;
+  box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.1);
+  width: 80%;
+
+  @media (max-width: ${theme.breakpoints.values.md}px) {
+    width: 100% !important;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 16px 0 !important;
+    box-shadow: none;
+  }
+`;
+
+export const SearchField = styled(TextField)`
+  margin: 32px 0;
+  background: ${theme.palette.background.default};
+  width: 100% !important;
+  border-radius: 12px !important;
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    margin: 16px 0 !important;
+  }
+
+  fieldset {
+    border-width: 0;
+
+    :focus {
+      border-width: 1px !important;
+    }
+  }
+`;

--- a/src/service/requests/useListSubjectsRequest/index.tsx
+++ b/src/service/requests/useListSubjectsRequest/index.tsx
@@ -1,0 +1,45 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import {
+  TListSubjectsErrorResponse,
+  TListSubjectsParams,
+  TListSubjectsResponse,
+} from './types';
+
+const useListSubjectsRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [data, setData] = useState<TListSubjectsResponse>();
+
+  const listSubjects = async (params?: TListSubjectsParams) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    try {
+      const response = await api.get('/subject', { params });
+
+      setData(response.data as TListSubjectsResponse);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TListSubjectsErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during list subjects. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    data,
+    error,
+    listSubjects,
+  };
+};
+
+export default useListSubjectsRequest;

--- a/src/service/requests/useListSubjectsRequest/types.ts
+++ b/src/service/requests/useListSubjectsRequest/types.ts
@@ -1,0 +1,30 @@
+export type TSubject = {
+  id: number;
+  name: string;
+  code: string;
+  course_id: 1;
+};
+
+export type TListSubjectsResponse = {
+  meta: {
+    current_page: number;
+    items_per_page: number;
+    total_pages: number;
+    total_items: number;
+  };
+  data: TSubject[];
+};
+
+export type TListSubjectsParams = {
+  quantity?: number;
+  number?: number;
+  page?: number;
+  field?: string;
+  order?: 'asc' | 'desc';
+  search?: string;
+};
+
+export type TListSubjectsErrorResponse = {
+  statusCode: number;
+  message: string;
+};

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -7,5 +7,6 @@ export const SCREENS = {
   CREATE_STUDENT: '/register/student',
   CREATE_PROFESSOR: '/register/professor',
   SUBJECTS: '/subjects',
+  SUBJECT_DETAILS: '/subjects/:id',
   MONITOR_REQUESTS: '/monitor-requests',
 };


### PR DESCRIPTION
# Descrição

- Cria tela de disciplinas de acordo com o **[Figma](https://www.figma.com/file/rtjsSZDBG51KFRigOgGo3E/Super-Monitoria---Componentes-e-Branding-v1.0?node-id=1297%3A7980&t=wi2oxnZmk3qVsdt1-0)**
- Cria tela provisória de detalhes de disciplina
- Corrige os testes de snapshot após mudança no `line-height` do `body1`

# Setup

- [x] `yarn start`


# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Listagem de disciplinas

- [x] Faça login e verifique se foi redirecionado para a tela de disciplinas.
- [x] Verifique se as disciplinas foram carregadas e mostradas corretamente.
- [x] Verifique se a lista de disciplinas está de acordo com o Figma nas versões PC, tablet e mobile.

## 2. Busca por disciplina

- [x] Na tela de disciplinas faça uma busca que seja satisfeira por alguma disciplina.
- [x] Verifique se a tela foi carregada novamente somete com as disciplinas que satisfazem a busca.
- [x] Faça uma busca que não seja satisfeita por disciplina nenhuma.
- [x] Verifique se o texto de disciplina não encontrada foi mostrado.

## 3. Ações nas disciplinas

- [x] Na tela de disciplinas, clique no card de alguma disciplina.
- [x] Verifique se foi redirecionado para a tela de detalhes da disciplina com o ID da disciplina escolhida. A URI dela é `/subjects/:id`.
- [x] Volta à tela de disciplinas e clique no botão de Agendar/Adicionar professor.
- [x] Verifique se um alerta foi mostrado indicando a ação selecionada com o ID da disciplina escolhida.
