### PR TITLE
feat: Modal de assinalar professor a disciplina

### DIFF
--- a/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
+++ b/src/__tests__/screens/codeVerification/__snapshots__/CodeVerification.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":r7:"
         onBlur={[Function]}
@@ -108,7 +108,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-1k4toxz-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -144,7 +144,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
           className="sc-kDvujY MuiBox-root css-ef4drl"
         >
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={false}
             id=":r8:"
             onBlur={[Function]}
@@ -168,7 +168,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
             />
           </button>
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-dqnh4x-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-1jqwl7k-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={true}
             id="code-verification-resend-code-button"
             onBlur={[Function]}
@@ -188,7 +188,7 @@ exports[`Test Code Verification screen snapshot tests should load code generatio
             type="button"
           >
             <div
-              className="MuiLoadingButton-loadingIndicator MuiLoadingButton-loadingIndicatorCenter css-likury-MuiLoadingButton-loadingIndicator"
+              className="MuiLoadingButton-loadingIndicator MuiLoadingButton-loadingIndicatorCenter css-sro313-MuiLoadingButton-loadingIndicator"
             >
               <span
                 aria-labelledby="code-verification-resend-code-button"
@@ -283,7 +283,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":rc:"
         onBlur={[Function]}
@@ -355,7 +355,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-1k4toxz-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -391,7 +391,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
           className="sc-kDvujY MuiBox-root css-ef4drl"
         >
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={false}
             id=":rd:"
             onBlur={[Function]}
@@ -415,7 +415,7 @@ exports[`Test Code Verification screen snapshot tests should render code generat
             />
           </button>
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-dqnh4x-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-1jqwl7k-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={false}
             id="code-verification-resend-code-button"
             onBlur={[Function]}
@@ -503,7 +503,7 @@ exports[`Test Code Verification screen snapshot tests should render code verifie
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":ra:"
         onBlur={[Function]}
@@ -563,7 +563,7 @@ exports[`Test Code Verification screen snapshot tests should render code verifie
         Agora que seu cadastro foi concluído você poderá aproveitar para solicitar ajuda dos monitores sempre que precisar.
       </p>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe gBODOj css-1h7wy6h-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe gBODOj css-1w43yds-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id="code-verification-login-button"
         onBlur={[Function]}
@@ -645,7 +645,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":r3:"
         onBlur={[Function]}
@@ -717,7 +717,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-1k4toxz-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -758,7 +758,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
           className="sc-kDvujY MuiBox-root css-ef4drl"
         >
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={false}
             id=":r4:"
             onBlur={[Function]}
@@ -782,7 +782,7 @@ exports[`Test Code Verification screen snapshot tests should render invalid code
             />
           </button>
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-dqnh4x-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-1jqwl7k-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={true}
             id="code-verification-resend-code-button"
             onBlur={[Function]}
@@ -868,7 +868,7 @@ exports[`Test Code Verification screen snapshot tests should render loading veri
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":r6:"
         onBlur={[Function]}
@@ -978,7 +978,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
         </p>
       </div>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+        className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-hLBbgP eSRjKV gRhBOZ css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
         disabled={false}
         id=":r0:"
         onBlur={[Function]}
@@ -1047,7 +1047,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
         }
       >
         <div
-          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-ihtv7a-MuiInputBase-root-MuiOutlinedInput-root"
+          className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary sc-ftTHYK sc-jrcTuL beuLgP hWFQHY css-1k4toxz-MuiInputBase-root-MuiOutlinedInput-root"
           onClick={[Function]}
         >
           <input
@@ -1083,7 +1083,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
           className="sc-kDvujY MuiBox-root css-ef4drl"
         >
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={false}
             id=":r1:"
             onBlur={[Function]}
@@ -1104,7 +1104,7 @@ exports[`Test Code Verification screen snapshot tests should render screen 1`] =
             Concluir o cadastro
           </button>
           <button
-            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj fWsFUP css-dqnh4x-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+            className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium sc-bcXHqe sc-ipEyDJ gBODOj dSjGWE css-1jqwl7k-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
             disabled={true}
             id="code-verification-resend-code-button"
             onBlur={[Function]}

--- a/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
+++ b/src/__tests__/screens/login/__snapshots__/Login.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -113,7 +113,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -169,7 +169,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -210,7 +210,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -270,7 +270,7 @@ exports[`Test Login screen snapshot tests should render screen 1`] = `
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={false}
                 id=":r1:"
                 onBlur={[Function]}
@@ -420,7 +420,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -471,7 +471,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -532,7 +532,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -573,7 +573,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -633,7 +633,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid e-ma
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={false}
                 id=":r5:"
                 onBlur={[Function]}
@@ -783,7 +783,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -837,7 +837,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -893,7 +893,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -934,7 +934,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -997,7 +997,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid logi
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={false}
                 id=":rb:"
                 onBlur={[Function]}
@@ -1150,7 +1150,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -1204,7 +1204,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1260,7 +1260,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary Mui-error MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1301,7 +1301,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -1369,7 +1369,7 @@ exports[`Test Login screen snapshot tests should render screen with invalid pass
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={false}
                 id=":r7:"
                 onBlur={[Function]}
@@ -1522,7 +1522,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -1576,7 +1576,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1632,7 +1632,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -1673,7 +1673,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -1736,7 +1736,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium Mui-disabled MuiButton-root MuiLoadingButton-root MuiLoadingButton-loading MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={true}
                 id=":r3:"
                 onBlur={[Function]}
@@ -1755,7 +1755,7 @@ exports[`Test Login screen snapshot tests should render screen with loading logi
                 type="submit"
               >
                 <div
-                  className="MuiLoadingButton-loadingIndicator MuiLoadingButton-loadingIndicatorCenter css-likury-MuiLoadingButton-loadingIndicator"
+                  className="MuiLoadingButton-loadingIndicator MuiLoadingButton-loadingIndicatorCenter css-sro313-MuiLoadingButton-loadingIndicator"
                 >
                   <span
                     aria-labelledby=":r3:"
@@ -1916,7 +1916,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
           </p>
         </div>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-18fs5t5-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+          className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedSecondary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-dIfARi cLAbaM bHKQDj css-1gvy6f3-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
           disabled={false}
           id="login-register-button"
           onBlur={[Function]}
@@ -1967,7 +1967,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
               className="MuiBox-root css-8atqhb"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-zv5y65-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart sc-iBYQkv dVmWfp css-2ycegv-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -2023,7 +2023,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
               className="MuiBox-root css-8875ym"
             >
               <div
-                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1cn2n3g-MuiInputBase-root-MuiOutlinedInput-root"
+                className="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-adornedStart MuiInputBase-adornedEnd sc-iBYQkv dVmWfp css-1nzt4e0-MuiInputBase-root-MuiOutlinedInput-root"
                 onClick={[Function]}
               >
                 <div
@@ -2064,7 +2064,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
                 >
                   <button
                     aria-label="toggle password visibility"
-                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-1jew56n-MuiButtonBase-root-MuiIconButton-root"
+                    className="MuiButtonBase-root MuiIconButton-root MuiIconButton-edgeEnd MuiIconButton-sizeMedium css-gxoo4k-MuiButtonBase-root-MuiIconButton-root"
                     disabled={false}
                     id="login-show-password-icon-button"
                     onBlur={[Function]}
@@ -2124,7 +2124,7 @@ exports[`Test Login screen snapshot tests should render screen with password sho
                 Esqueci minha senha
               </a>
               <button
-                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-105755-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
+                className="MuiButtonBase-root MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-root MuiLoadingButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium sc-ftTHYK sc-csuSiG khrxOW iqjFsB css-2urf4o-MuiButtonBase-root-MuiButton-root-MuiLoadingButton-root"
                 disabled={false}
                 id=":r9:"
                 onBlur={[Function]}

--- a/src/components/assignProfessorsModal/hooks/types.ts
+++ b/src/components/assignProfessorsModal/hooks/types.ts
@@ -1,0 +1,4 @@
+export type TSelectedProfessor = {
+  id: number;
+  name: string;
+};

--- a/src/components/assignProfessorsModal/hooks/useAssignProfessorsModal.ts
+++ b/src/components/assignProfessorsModal/hooks/useAssignProfessorsModal.ts
@@ -1,0 +1,90 @@
+import { SelectChangeEvent } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import useAssignProfessorsRequest from '../../../service/requests/useAssignProfessorsRequest';
+import useListProfessorsRequest from '../../../service/requests/useListProfessorsRequest';
+import { TSubject } from '../../../service/requests/useListSubjectsRequest/types';
+import { useSnackBar } from '../../../utils/renderSnackBar';
+import { TSelectedProfessor } from './types';
+
+const useAssignProfessorsModal = () => {
+  const { data: listProfessorsResponse, listProfessors } =
+    useListProfessorsRequest();
+  const { isSuccess, isLoading, assignProfessors, error, resetStates } =
+    useAssignProfessorsRequest();
+  const { showErrorSnackBar } = useSnackBar();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedSubject, setSelectedSubject] = useState<TSubject>();
+  const [selectedProfessorsIds, setSelectedProfessorsIds] = useState<string[]>(
+    []
+  );
+
+  const professors: TSelectedProfessor[] = useMemo(() => {
+    if (!listProfessorsResponse) return [];
+
+    const notAssignedProfessors = listProfessorsResponse.data.filter(
+      (prof) =>
+        prof.SubjectResponsability.find(
+          (resp) => resp.subject.code === selectedSubject?.code
+        ) === undefined
+    );
+
+    return notAssignedProfessors.map((professor) => ({
+      id: professor.user.id,
+      name: professor.user.name,
+    }));
+  }, [listProfessorsResponse, selectedSubject]);
+
+  const handleCloseModal = () => {
+    setIsOpen(false);
+    resetStates();
+    setSelectedProfessorsIds([]);
+  };
+
+  const handleOpenModal = (subject: TSubject) => {
+    setSelectedSubject(subject);
+    setIsOpen(true);
+  };
+
+  const handleChangeProfessors = (event: SelectChangeEvent<string[]>) => {
+    const {
+      target: { value },
+    } = event;
+
+    setSelectedProfessorsIds(
+      typeof value === 'string' ? value.split(',') : value
+    );
+  };
+
+  const handleAssignProfessorsClick = () => {
+    assignProfessors({
+      professors_ids: selectedProfessorsIds.map((id) => Number(id)),
+      subject_id: selectedSubject?.id as number,
+    });
+  };
+
+  useEffect(() => {
+    void listProfessors({ quantity: 1000 });
+  }, []);
+
+  useEffect(() => {
+    if (error) {
+      showErrorSnackBar(`Erro ao adicionar professores. Erro: ${error}`);
+    }
+  }, [error]);
+
+  return {
+    isLoading,
+    isSuccess,
+    isOpen,
+    professors,
+    selectedProfessorsIds,
+    selectedSubject,
+    handleAssignProfessorsClick,
+    handleChangeProfessors,
+    handleCloseModal,
+    handleOpenModal,
+  };
+};
+
+export default useAssignProfessorsModal;

--- a/src/components/assignProfessorsModal/index.tsx
+++ b/src/components/assignProfessorsModal/index.tsx
@@ -1,0 +1,146 @@
+import {
+  Chip,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+} from '@mui/material';
+import { TSelectedProfessor } from './hooks/types';
+import { TSubject } from '../../service/requests/useListSubjectsRequest/types';
+import { Button } from '../button';
+import CheckedAnimation from '../checkedAnimation';
+import LoadingAnimation from '../loadingAnimation';
+import Modal from '../modal';
+import { TextField } from '../textField';
+import {
+  ButtonsContainer,
+  ChipsContainer,
+  ConfirmationContainer,
+  ConfirmationTextContainer,
+  LoadingContainer,
+  MenuProps,
+  Placeholder,
+  StyledTypography,
+} from './styles';
+
+type Props = {
+  isLoading: boolean;
+  isSuccess: boolean;
+  isOpen: boolean;
+  professors: TSelectedProfessor[];
+  selectedProfessorsIds: string[];
+  subject?: TSubject;
+  handleAssignProfessorsClick(): void;
+  handleChangeProfessors(event: SelectChangeEvent<string[]>): void;
+  handleClose(): void;
+};
+
+const AssignProfessorsModal = ({
+  isLoading,
+  isSuccess,
+  isOpen,
+  professors,
+  selectedProfessorsIds,
+  subject,
+  handleAssignProfessorsClick,
+  handleChangeProfessors,
+  handleClose,
+}: Props) => {
+  if (!subject) return <></>;
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <LoadingContainer>
+          <LoadingAnimation />
+        </LoadingContainer>
+      );
+    }
+
+    if (isSuccess) {
+      return (
+        <ConfirmationContainer>
+          <CheckedAnimation />
+
+          <ConfirmationTextContainer>
+            <Typography variant="h4">Tudo certo!</Typography>
+            <Typography variant="body1">
+              Todos os professores foram adicionados
+            </Typography>
+          </ConfirmationTextContainer>
+
+          <Button onClick={handleClose} color="primary">
+            Voltar
+          </Button>
+        </ConfirmationContainer>
+      );
+    }
+
+    return (
+      <>
+        <StyledTypography variant="h4">Adicionar Professor</StyledTypography>
+
+        <StyledTypography variant="body1">
+          Selecione um Professor para torná-lo responsável pela disciplina{' '}
+          <strong>
+            {subject.code} - {subject.name}
+          </strong>
+          .
+        </StyledTypography>
+
+        <Select
+          multiple
+          displayEmpty
+          value={selectedProfessorsIds}
+          onChange={handleChangeProfessors}
+          input={<TextField />}
+          renderValue={(selected: string[]) =>
+            selected.length === 0 ? (
+              <Placeholder>Selecionar Professor</Placeholder>
+            ) : (
+              <ChipsContainer>
+                {selected.map((id: string) => (
+                  <Chip
+                    key={id}
+                    label={
+                      professors.find((prof) => prof.id === Number(id))?.name ||
+                      ''
+                    }
+                  />
+                ))}
+              </ChipsContainer>
+            )
+          }
+          MenuProps={MenuProps}
+        >
+          {professors.map((professor) => (
+            <MenuItem key={professor.id} value={professor.id}>
+              {professor.name}
+            </MenuItem>
+          ))}
+        </Select>
+
+        <ButtonsContainer>
+          <Button variant="text" color="primary" onClick={handleClose}>
+            Cancelar
+          </Button>
+          <Button
+            disabled={!selectedProfessorsIds.length}
+            color="primary"
+            onClick={handleAssignProfessorsClick}
+          >
+            Adicionar
+          </Button>
+        </ButtonsContainer>
+      </>
+    );
+  };
+
+  return (
+    <Modal isOpen={isOpen} handleClose={handleClose}>
+      {renderContent()}
+    </Modal>
+  );
+};
+
+export default AssignProfessorsModal;

--- a/src/components/assignProfessorsModal/styles.ts
+++ b/src/components/assignProfessorsModal/styles.ts
@@ -1,0 +1,74 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../utils/theme';
+
+export const StyledTypography = styled(Typography).attrs({})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    text-align: center !important;
+  }
+`;
+
+export const ButtonsContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '24px',
+  marginTop: '16px',
+})``;
+
+export const Placeholder = styled(Typography).attrs({
+  variant: 'body1',
+})`
+  color: ${theme.palette.grey[600]} !important;
+`;
+
+export const ChipsContainer = styled(Box).attrs({
+  display: 'flex',
+  flexWrap: 'wrap',
+  gap: 0.5,
+})``;
+
+export const LoadingContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+  padding: '16px 0',
+})``;
+
+export const ConfirmationContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  gap: '24px',
+  padding: '16px 0',
+})``;
+
+export const ConfirmationTextContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '8px',
+})``;
+
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+
+export const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+      backgroundColor: 'white',
+      boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.1)',
+    },
+  },
+  sx: {
+    '&& .Mui-selected': {
+      backgroundColor: theme.palette.grey[200],
+      ':hover': {
+        backgroundColor: theme.palette.grey[300],
+      },
+    },
+  },
+};

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,0 +1,17 @@
+import { Modal as MuiMiodal } from '@mui/material';
+import React from 'react';
+import { Container } from './styles';
+
+type Props = {
+  isOpen: boolean;
+  handleClose(): void;
+  children: React.ReactNode;
+};
+
+const Modal = ({ isOpen, handleClose, children }: Props) => (
+  <MuiMiodal open={isOpen} onClose={handleClose}>
+    <Container>{children}</Container>
+  </MuiMiodal>
+);
+
+export default Modal;

--- a/src/components/modal/styles.ts
+++ b/src/components/modal/styles.ts
@@ -1,0 +1,21 @@
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '24px',
+  backgroundColor: 'white',
+  padding: '24px',
+})`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  max-width: 752px;
+  width: 80%;
+
+  border-radius: 24px;
+  box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.1);
+`;

--- a/src/screens/codeVerification/styles.ts
+++ b/src/screens/codeVerification/styles.ts
@@ -1,3 +1,4 @@
+import { alpha } from '@material-ui/core';
 import { Box } from '@mui/system';
 import styled from 'styled-components';
 import { Button } from '../../components/button';
@@ -43,6 +44,9 @@ export const CodeFormButton = styled(Button).attrs({
 })`
   width: 100%;
   min-width: 245px;
+  :disabled {
+    color: ${alpha(theme.palette.primary.main, 0.5)} !important;
+  }
 `;
 
 export const CopyRigthContainer = styled(Box).attrs({

--- a/src/screens/subjects/components/SubjectsList/index.tsx
+++ b/src/screens/subjects/components/SubjectsList/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   totalPages: number;
   subjects?: TSubject[];
   userTypeId?: number;
-  handleAddProfessor(id: number): void;
+  handleAssignProfessors(subject: TSubject): void;
   handleChangePage(event: React.ChangeEvent<unknown>, page: number): void;
   handleSubjectClick(id: number): void;
   handleScheduleHelp(id: number): void;
@@ -28,7 +28,7 @@ const SubjectsList = ({
   totalPages,
   subjects,
   userTypeId,
-  handleAddProfessor,
+  handleAssignProfessors,
   handleChangePage,
   handleScheduleHelp,
   handleSubjectClick,
@@ -64,7 +64,7 @@ const SubjectsList = ({
             key={subject.id}
             subject={subject}
             userTypeId={userTypeId}
-            handleAddProfessor={handleAddProfessor}
+            handleAssignProfessors={handleAssignProfessors}
             handleScheduleHelp={handleScheduleHelp}
             handleSubjectClick={handleSubjectClick}
           />

--- a/src/screens/subjects/components/SubjectsListItem/index.tsx
+++ b/src/screens/subjects/components/SubjectsListItem/index.tsx
@@ -14,7 +14,7 @@ import {
 type Props = {
   subject: TSubject;
   userTypeId?: number;
-  handleAddProfessor(id: number): void;
+  handleAssignProfessors(subject: TSubject): void;
   handleScheduleHelp(id: number): void;
   handleSubjectClick(id: number): void;
 };
@@ -22,7 +22,7 @@ type Props = {
 const SubjectsListItem = ({
   subject,
   userTypeId,
-  handleAddProfessor,
+  handleAssignProfessors,
   handleScheduleHelp,
   handleSubjectClick,
 }: Props) => {
@@ -44,7 +44,7 @@ const SubjectsListItem = ({
       return (
         <ButtonContainer>
           <ActionButton
-            onClick={() => handleAddProfessor(subject.id)}
+            onClick={() => handleAssignProfessors(subject)}
             startIcon={<Add />}
           >
             Professor

--- a/src/screens/subjects/components/SubjectsListItem/styles.ts
+++ b/src/screens/subjects/components/SubjectsListItem/styles.ts
@@ -12,7 +12,7 @@ export const StyledCard = styled(Card).attrs({
   padding: 16px 24px;
 
   :hover {
-    background-color: ${theme.palette.grey.A100} !important;
+    background-color: ${theme.palette.grey[200]} !important;
     cursor: pointer;
     transition: 0.8s;
   }

--- a/src/screens/subjects/hooks/useSubjects.ts
+++ b/src/screens/subjects/hooks/useSubjects.ts
@@ -2,11 +2,13 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useListSubjectsRequest from '../../../service/requests/useListSubjectsRequest';
 import useGetLoggedUser from '../../../service/storage/getLoggedUser';
+import { useSnackBar } from '../../../utils/renderSnackBar';
 import { SCREENS } from '../../../utils/screens';
 
 const useSubjects = () => {
   const navigate = useNavigate();
   const user = useGetLoggedUser();
+  const { showErrorSnackBar } = useSnackBar();
 
   const {
     data: subjectsResponse,
@@ -47,11 +49,6 @@ const useSubjects = () => {
     navigate(SCREENS.SUBJECT_DETAILS.replace(':id', subjectId.toString()));
   };
 
-  const handleAddProfessor = (subjectId: number) => {
-    // TODO - Adicionar modal
-    alert(`Add professor para a disciplina ${subjectId}`);
-  };
-
   const handleScheduleHelp = (subjectId: number) => {
     // TODO - Adicionar modal
     alert(`Agendar ajuda na disciplina ${subjectId}`);
@@ -65,8 +62,7 @@ const useSubjects = () => {
 
   useEffect(() => {
     if (subjectsError) {
-      // TODO - Mudar para snackbar
-      alert(`Erro ao carregar disciplinas. Erro: ${subjectsError}`);
+      showErrorSnackBar(`Erro ao carregar disciplinas. Erro: ${subjectsError}`);
     }
   }, [subjectsError]);
 
@@ -77,7 +73,6 @@ const useSubjects = () => {
     subjects,
     isLoadingSubjects,
     searchFieldElement,
-    handleAddProfessor,
     handleChangePage,
     handleScheduleHelp,
     handleSearch,

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -2,7 +2,9 @@ import { Search } from '@mui/icons-material';
 import { InputAdornment, Typography } from '@mui/material';
 import ContainerWithSidebar from '../../components/containerWithSidebar';
 import { SidebarItemEnum } from '../../utils/constants';
+import AssignProfessorsModal from '../../components/assignProfessorsModal';
 import SubjectsList from './components/SubjectsList';
+import useAssignProfessorsModal from '../../components/assignProfessorsModal/hooks/useAssignProfessorsModal';
 import useSubjects from './hooks/useSubjects';
 import { Card, Container, SearchField } from './styles';
 
@@ -14,15 +16,38 @@ const Subjects = () => {
     isLoadingSubjects,
     searchFieldElement,
     userTypeId,
-    handleAddProfessor,
     handleChangePage,
     handleScheduleHelp,
     handleSearch,
     handleSubjectClick,
   } = useSubjects();
 
+  const {
+    isLoading: isLoadingAssignProfessors,
+    isSuccess,
+    isOpen: isAssignProfessorsModalOpen,
+    professors,
+    selectedProfessorsIds,
+    selectedSubject,
+    handleAssignProfessorsClick,
+    handleChangeProfessors,
+    handleCloseModal: handleCloseAssignProfessorsModal,
+    handleOpenModal: handleOpenAssignProfessorsModal,
+  } = useAssignProfessorsModal();
+
   return (
     <ContainerWithSidebar selectedSidebarItem={SidebarItemEnum.SUBJECTS}>
+      <AssignProfessorsModal
+        isLoading={isLoadingAssignProfessors}
+        isSuccess={isSuccess}
+        isOpen={isAssignProfessorsModalOpen}
+        professors={professors}
+        selectedProfessorsIds={selectedProfessorsIds}
+        subject={selectedSubject}
+        handleAssignProfessorsClick={handleAssignProfessorsClick}
+        handleChangeProfessors={handleChangeProfessors}
+        handleClose={handleCloseAssignProfessorsModal}
+      />
       <Container>
         <Card>
           <Typography variant="h3">Disciplinas</Typography>
@@ -49,7 +74,7 @@ const Subjects = () => {
             subjects={subjects}
             userTypeId={userTypeId}
             isLoading={isLoadingSubjects}
-            handleAddProfessor={handleAddProfessor}
+            handleAssignProfessors={handleOpenAssignProfessorsModal}
             handleChangePage={handleChangePage}
             handleScheduleHelp={handleScheduleHelp}
             handleSubjectClick={handleSubjectClick}

--- a/src/service/requests/useAssignProfessorsRequest/index.ts
+++ b/src/service/requests/useAssignProfessorsRequest/index.ts
@@ -1,0 +1,50 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import {
+  TAssignProfessorsErrorResponse,
+  TAssignProfessorsRequest,
+} from './types';
+
+const useAssignProfessorsRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const assignProfessors = async (body: TAssignProfessorsRequest) => {
+    setIsLoading(true);
+    setIsSuccess(false);
+    setError(undefined);
+
+    try {
+      await api.post('/teacher/assign-subject', body);
+
+      setIsSuccess(true);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TAssignProfessorsErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during assign professors. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetStates = () => {
+    setError(undefined);
+    setIsSuccess(false);
+  };
+
+  return {
+    isLoading,
+    isSuccess,
+    error,
+    assignProfessors,
+    resetStates,
+  };
+};
+
+export default useAssignProfessorsRequest;

--- a/src/service/requests/useAssignProfessorsRequest/types.ts
+++ b/src/service/requests/useAssignProfessorsRequest/types.ts
@@ -1,0 +1,10 @@
+export type TAssignProfessorsRequest = {
+  professors_ids: number[];
+  subject_id: number;
+};
+
+export type TAssignProfessorsErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};

--- a/src/service/requests/useListProfessorsRequest/index.tsx
+++ b/src/service/requests/useListProfessorsRequest/index.tsx
@@ -1,0 +1,45 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import {
+  TListProfessorsErrorResponse,
+  TListProfessorsParams,
+  TListProfessorsResponse,
+} from './types';
+
+const useListProfessorsRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [data, setData] = useState<TListProfessorsResponse>();
+
+  const listProfessors = async (params?: TListProfessorsParams) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    try {
+      const response = await api.get('/teacher', { params });
+
+      setData(response.data as TListProfessorsResponse);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TListProfessorsErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during list professors. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    data,
+    error,
+    listProfessors,
+  };
+};
+
+export default useListProfessorsRequest;

--- a/src/service/requests/useListProfessorsRequest/types.ts
+++ b/src/service/requests/useListProfessorsRequest/types.ts
@@ -1,0 +1,43 @@
+export type TSubjectResponsability = {
+  status: 'Pendente';
+  subject: {
+    name: string;
+    code: string;
+  };
+};
+
+export type TProfessor = {
+  id: number;
+  name: string;
+  email: string;
+  is_verified: false;
+};
+
+export type TProfessorData = {
+  user: TProfessor;
+  SubjectResponsability: TSubjectResponsability[];
+};
+
+export type TListProfessorsResponse = {
+  meta: {
+    current_page: number;
+    items_per_page: number;
+    total_pages: number;
+    total_items: number;
+  };
+  data: TProfessorData[];
+};
+
+export type TListProfessorsParams = {
+  quantity?: number;
+  number?: number;
+  page?: number;
+  field?: string;
+  order?: 'asc' | 'desc';
+  search?: string;
+};
+
+export type TListProfessorsErrorResponse = {
+  statusCode: number;
+  message: string;
+};

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -42,7 +42,7 @@ const theme = createTheme({
       paper: '#65B95E',
     },
     action: {
-      disabled: '#65B95E66',
+      disabled: '#fff',
       disabledBackground: '#70D26866',
     },
   },


### PR DESCRIPTION
# Descrição

- Cria componente de modal
- Cria modal de assinalar professor a disciplina

# Setup

- [x] `yarn start`
- [x] Faça login com a conta de coordenador: `nabson.paiva@icomp.ufam.edu.br` | `12345678`.

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Assinalar professor

- [x] Na tela de disciplinas, pressione o botão de assinalar professor ao lado de uma das disciplinas.
- [x] Verifique se a modal de assinalar professor foi mostrada com o botão desabilitado.
- [x] Selecione um ou mais professores para assinalar para a disciplina.
- [x] Verifique que o botão de confirmar foi habilitado e pressione-o.
- [x] Verifique se o loading foi mostrado seguido da modal de confirmação.
- [x] Pressione voltar e verifique se a modal foi fechada.
- [x] Refaça os passos acima para as dimensões de tablet e mobile e confira a responsividade da modal.
