### PR TITLE
feat: Modal de quero ser monitor

### DIFF
--- a/src/components/addMonitorModal/hooks/useAddMonitorModal.ts
+++ b/src/components/addMonitorModal/hooks/useAddMonitorModal.ts
@@ -1,0 +1,79 @@
+import { SelectChangeEvent } from '@mui/material';
+import { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import useAddMonitorRequest from '../../../service/requests/useAddMonitorRequest';
+import {
+  TCompleteSubject,
+  TSubjectResponsible,
+} from '../../../service/requests/useGetSubject/types';
+import useGetLoggedUser from '../../../service/storage/getLoggedUser';
+import { useSnackBar } from '../../../utils/renderSnackBar';
+
+const useAddMonitorModal = () => {
+  const navigate = useNavigate();
+  const user = useGetLoggedUser();
+  const { showErrorSnackBar } = useSnackBar();
+
+  const { isSuccess, isLoading, addMonitor, error, resetStates } =
+    useAddMonitorRequest();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedSubject, setSelectedSubject] = useState<TCompleteSubject>();
+  const [selectedProfessorId, setSelectedProfessorId] = useState(-1);
+
+  const professors: TSubjectResponsible[] = useMemo(() => {
+    if (!selectedSubject) return [];
+
+    return selectedSubject.responsables;
+  }, [selectedSubject]);
+
+  const handleCloseModal = () => {
+    setIsOpen(false);
+    resetStates();
+    setSelectedProfessorId(-1);
+
+    if (isSuccess) navigate(0);
+  };
+
+  const handleOpenModal = (subject: TCompleteSubject) => {
+    setSelectedSubject(subject);
+    setIsOpen(true);
+  };
+
+  const handleChangeProfessor = (event: SelectChangeEvent<string[]>) => {
+    const {
+      target: { value },
+    } = event;
+
+    setSelectedProfessorId(Number(value));
+  };
+
+  const handleAddMonitorClick = () => {
+    addMonitor(user ? Number(user.sub) : -1, {
+      professor_id: selectedProfessorId,
+      subject_id: selectedSubject?.id as number,
+    });
+  };
+
+  useEffect(() => {
+    if (error) {
+      showErrorSnackBar(`Erro ao solicitar para ser monitor. Erro: ${error}`);
+    }
+  }, [error]);
+
+  return {
+    userId: user?.sub,
+    isLoading,
+    isSuccess,
+    isOpen,
+    professors,
+    selectedProfessorId,
+    selectedSubject,
+    handleAddMonitorClick,
+    handleChangeProfessor,
+    handleCloseModal,
+    handleOpenModal,
+  };
+};
+
+export default useAddMonitorModal;

--- a/src/components/addMonitorModal/index.tsx
+++ b/src/components/addMonitorModal/index.tsx
@@ -1,0 +1,136 @@
+import { MenuItem, Select, SelectChangeEvent, Typography } from '@mui/material';
+import { TSubjectResponsible } from '../../service/requests/useGetSubject/types';
+import { TSubject } from '../../service/requests/useListSubjectsRequest/types';
+import { Button } from '../button';
+import CheckedAnimation from '../checkedAnimation';
+import LoadingAnimation from '../loadingAnimation';
+import Modal from '../modal';
+import { TextField } from '../textField';
+import {
+  ButtonsContainer,
+  ConfirmationContainer,
+  ConfirmationTextContainer,
+  ConfirmButton,
+  LoadingContainer,
+  Placeholder,
+  StyledTypography,
+} from './styles';
+
+type Props = {
+  isLoading: boolean;
+  isSuccess: boolean;
+  isOpen: boolean;
+  professors: TSubjectResponsible[];
+  selectedProfessorId: number;
+  subject?: TSubject;
+  handleAddMonitorClick(): void;
+  handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
+  handleClose(): void;
+};
+
+const AddMonitorModal = ({
+  isLoading,
+  isSuccess,
+  isOpen,
+  professors,
+  selectedProfessorId,
+  subject,
+  handleAddMonitorClick,
+  handleChangeProfessor,
+  handleClose,
+}: Props) => {
+  if (!subject) return <></>;
+
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <LoadingContainer>
+          <LoadingAnimation />
+        </LoadingContainer>
+      );
+    }
+
+    if (isSuccess) {
+      return (
+        <ConfirmationContainer>
+          <CheckedAnimation />
+
+          <ConfirmationTextContainer>
+            <Typography variant="h4">Tudo certo!</Typography>
+            <Typography variant="body1" textAlign={'center'}>
+              Sua solicitação foi enviada, aguarde a confirmação do professor
+              para concluir sua mudança de perfil.
+            </Typography>
+          </ConfirmationTextContainer>
+
+          <Button onClick={handleClose} color="primary">
+            Voltar
+          </Button>
+        </ConfirmationContainer>
+      );
+    }
+
+    return (
+      <>
+        <StyledTypography variant="h4">Quero ser Monitor</StyledTypography>
+
+        <StyledTypography variant="body1">
+          Informe qual professor você desejar ser monitor da disciplina{' '}
+          <strong>
+            {subject.code} - {subject.name}
+          </strong>
+          .
+        </StyledTypography>
+
+        <Select
+          displayEmpty
+          value={[selectedProfessorId.toFixed()]}
+          onChange={handleChangeProfessor}
+          input={<TextField />}
+          renderValue={(selected: string[]) =>
+            Number(selected) === -1 ? (
+              <Placeholder>Selecionar Professor</Placeholder>
+            ) : (
+              <Typography>
+                {professors.find((prof) => prof.id === Number(selected[0]))
+                  ?.name || ''}
+              </Typography>
+            )
+          }
+        >
+          {[
+            <MenuItem key={-1} value={-1}>
+              Selecionar Professor
+            </MenuItem>,
+            ...professors.map((professor) => (
+              <MenuItem key={professor.id} value={professor.id}>
+                {professor.name}
+              </MenuItem>
+            )),
+          ]}
+        </Select>
+
+        <ButtonsContainer>
+          <Button variant="text" color="primary" onClick={handleClose}>
+            Cancelar
+          </Button>
+          <ConfirmButton
+            disabled={selectedProfessorId === -1}
+            color="primary"
+            onClick={handleAddMonitorClick}
+          >
+            Enviar solicitação
+          </ConfirmButton>
+        </ButtonsContainer>
+      </>
+    );
+  };
+
+  return (
+    <Modal isOpen={isOpen} handleClose={handleClose}>
+      {renderContent()}
+    </Modal>
+  );
+};
+
+export default AddMonitorModal;

--- a/src/components/addMonitorModal/styles.ts
+++ b/src/components/addMonitorModal/styles.ts
@@ -1,0 +1,55 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../utils/theme';
+import { Button } from '../button';
+
+export const StyledTypography = styled(Typography).attrs({})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    text-align: center !important;
+  }
+`;
+
+export const ButtonsContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '24px',
+  marginTop: '16px',
+})``;
+
+export const Placeholder = styled(Typography).attrs({
+  variant: 'body1',
+})`
+  color: ${theme.palette.grey[600]} !important;
+`;
+
+export const LoadingContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  width: '100%',
+  padding: '16px 0',
+})``;
+
+export const ConfirmationContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  width: '100%',
+  gap: '24px',
+  padding: '16px 0',
+})``;
+
+export const ConfirmationTextContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '8px',
+})``;
+
+export const ConfirmButton = styled(Button).attrs({
+  color: 'primary',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 250px !important;
+  }
+`;

--- a/src/screens/subjectDetails/components/subjectHeader/index.tsx
+++ b/src/screens/subjectDetails/components/subjectHeader/index.tsx
@@ -1,14 +1,16 @@
 import { AddRounded, ArrowBack } from '@mui/icons-material';
 import { IconButton } from '@mui/material';
+import AddMonitorModal from '../../../../components/addMonitorModal';
+import useAddMonitorModal from '../../../../components/addMonitorModal/hooks/useAddMonitorModal';
 import AssignProfessorsModal from '../../../../components/assignProfessorsModal';
 import useAssignProfessorsModal from '../../../../components/assignProfessorsModal/hooks/useAssignProfessorsModal';
 import { Button } from '../../../../components/button';
-import { TSubject } from '../../../../service/requests/useListSubjectsRequest/types';
+import { TCompleteSubject } from '../../../../service/requests/useGetSubject/types';
 import { TypeUserEnum } from '../../../../utils/constants';
 import { Container } from './styles';
 
 type Props = {
-  subject?: TSubject;
+  subject?: TCompleteSubject;
   userType: TypeUserEnum;
   handleGoBackClick(): void;
 };
@@ -26,12 +28,36 @@ const SubjectHeader = ({ subject, userType, handleGoBackClick }: Props) => {
     handleCloseModal: handleCloseAssignProfessorsModal,
     handleOpenModal: handleOpenAssignProfessorsModal,
   } = useAssignProfessorsModal();
+  const {
+    isLoading: isLoadingAddMonitor,
+    isSuccess: isSuccessAddMonitor,
+    isOpen: isAddMonitorModalOpen,
+    professors: addMonitorProfessors,
+    selectedProfessorId,
+    selectedSubject: selectedMonitorSubject,
+    userId,
+    handleAddMonitorClick,
+    handleChangeProfessor,
+    handleCloseModal: handleCloseAddMonitorModal,
+    handleOpenModal: handleOpenAddMonitorModal,
+  } = useAddMonitorModal();
 
   const renderButton = () => {
     if (!subject) return <></>;
 
-    if (userType === TypeUserEnum.STUDENT) {
-      return <Button color="secondary">Quero ser monitor</Button>;
+    if (
+      userType === TypeUserEnum.STUDENT &&
+      subject.responsables.length &&
+      !subject.monitors.find((monitor) => monitor.id === Number(userId))
+    ) {
+      return (
+        <Button
+          onClick={() => handleOpenAddMonitorModal(subject)}
+          color="secondary"
+        >
+          Quero ser monitor
+        </Button>
+      );
     }
 
     if (userType === TypeUserEnum.COORDINATOR) {
@@ -61,6 +87,17 @@ const SubjectHeader = ({ subject, userType, handleGoBackClick }: Props) => {
         handleAssignProfessorsClick={handleAssignProfessorsClick}
         handleChangeProfessors={handleChangeProfessors}
         handleClose={handleCloseAssignProfessorsModal}
+      />
+      <AddMonitorModal
+        isLoading={isLoadingAddMonitor}
+        isSuccess={isSuccessAddMonitor}
+        isOpen={isAddMonitorModalOpen}
+        professors={addMonitorProfessors}
+        selectedProfessorId={selectedProfessorId}
+        subject={selectedMonitorSubject}
+        handleAddMonitorClick={handleAddMonitorClick}
+        handleChangeProfessor={handleChangeProfessor}
+        handleClose={handleCloseAddMonitorModal}
       />
       <IconButton onClick={handleGoBackClick}>
         <ArrowBack />

--- a/src/screens/subjectDetails/index.tsx
+++ b/src/screens/subjectDetails/index.tsx
@@ -51,7 +51,9 @@ const SubjectDetails = () => {
         <Typography variant="h3">{subject.name}</Typography>
 
         <LegendTypography>
-          Aqui estão listados todos os professores e monitores desta disciplina
+          {userType === TypeUserEnum.STUDENT
+            ? 'Clique em um monitor para iniciar um agendamento.'
+            : 'Aqui estão listados todos os professores e monitores desta disciplina'}
         </LegendTypography>
       </>
     );

--- a/src/service/requests/useAddMonitorRequest/index.ts
+++ b/src/service/requests/useAddMonitorRequest/index.ts
@@ -1,0 +1,47 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import { TAddMonitorErrorResponse, TAddMonitorRequest } from './types';
+
+const useAddMonitorRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const addMonitor = async (studentId: number, body: TAddMonitorRequest) => {
+    setIsLoading(true);
+    setIsSuccess(false);
+    setError(undefined);
+
+    try {
+      await api.post(`/monitor/request/${studentId}`, body);
+
+      setIsSuccess(true);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TAddMonitorErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during assign professors. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetStates = () => {
+    setError(undefined);
+    setIsSuccess(false);
+  };
+
+  return {
+    isLoading,
+    isSuccess,
+    error,
+    addMonitor,
+    resetStates,
+  };
+};
+
+export default useAddMonitorRequest;

--- a/src/service/requests/useAddMonitorRequest/types.ts
+++ b/src/service/requests/useAddMonitorRequest/types.ts
@@ -1,0 +1,10 @@
+export type TAddMonitorRequest = {
+  subject_id: number;
+  professor_id: number;
+};
+
+export type TAddMonitorErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};

--- a/src/service/requests/useGetSubject/types.ts
+++ b/src/service/requests/useGetSubject/types.ts
@@ -1,6 +1,6 @@
 import { TSubject } from '../useListSubjectsRequest/types';
 
-type TSubjectProfessor = {
+export type TSubjectResponsible = {
   id: number;
   name: string;
   email: string;
@@ -22,7 +22,7 @@ export type TSubjectMonitor = {
 };
 
 export type TCompleteSubject = TSubject & {
-  responsables: TSubjectProfessor[];
+  responsables: TSubjectResponsible[];
   monitors: TSubjectMonitor[];
 };
 


### PR DESCRIPTION
# Descrição

- Cria modal de quero ser monitor.
- Adiciona modal de quero ser monitor na tela de detalhes de disciplina.
- Muda o texto na tela de detalhes de disciplina se o usuário for um aluno.
- Não mostra botão de quero ser monitor se a disciplina não tem professores ou se o aluno já é um monitor da disciplina.

# Setup

- [x] `yarn start`
- [x] Garanta que existe pelo menos uma disciplina com algum professor responsável.
- [x] Faça login com uma conta de aluno.

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Quero ser monitor

- [ ] Entre na tela de uma disciplina que possua pelo menos um professor responsável.
- [ ] Verifique se o botão de quero ser monitor foi mostrado.
- [ ] Pressione o botão de quero ser monitor.
- [ ] Escolha um dos professores responsáveis e confirme a solicitação.
- [ ] Verifique se a modal de carregamento apareceu seguida da modal de solicitação confirmada.
- [ ] Repita os passos acima nas dimensões de tablet e mobile.

## 2. Botão de ser monitor escondido

- [ ] Entre em uma disciplina que não tenha professores responsáveis.
- [ ] Verifique se o botão de quero ser monitor não está sendo mostrado.
- [ ] Entre em uma disciplina que vc ja seja monitor.
- [ ] Verifique se o botão de quero ser monitor não está sendo mostrado.
