### PR TITLE
fix: Atualiza rota de rejeitar monitoria

### DIFF
--- a/src/service/requests/useDenyMonitorRequest/index.ts
+++ b/src/service/requests/useDenyMonitorRequest/index.ts
@@ -2,35 +2,32 @@ import { AxiosError } from 'axios';
 import { useState } from 'react';
 import api from '../../api';
 import { TDenyMonitorErrorResponse } from './types';
-import { useSnackBar } from '../../../utils/renderSnackBar';
 
 const useDenyMonitorRequest = () => {
-  const { showInfoSnackBar } = useSnackBar();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string>();
   const [isSuccess, setIsSuccess] = useState(false);
 
   const denyMonitor = async (id_monitoring: number) => {
-    // setIsLoading(true);
-    // setIsSuccess(false);
-    // setError(undefined);
+    setIsLoading(true);
+    setIsSuccess(false);
+    setError(undefined);
 
-    // try {
-    //   await api.patch(`/monitor/${id_monitoring}/accept`);
+    try {
+      await api.patch(`/monitor/${id_monitoring}/refuse`);
 
-    //   setIsSuccess(true);
-    // } catch (error) {
-    //   const err = error as AxiosError;
-    //   const errorData = err.response?.data as TDenyMonitorErrorResponse;
-    //   const errorMessage = errorData?.message || 'Erro desconhecido';
+      setIsSuccess(true);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TDenyMonitorErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
 
-    //   console.error('Error during deny monitors. Error:', errorMessage);
+      console.error('Error during deny monitors. Error:', errorMessage);
 
-    //   setError(errorMessage);
-    // } finally {
-    //   setIsLoading(false);
-    // }
-    showInfoSnackBar('Feature ainda não disponível');
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const resetStates = () => {


### PR DESCRIPTION
# Descrição

Atualiza rota de rejeitar monitoria.

# Em casos de bugfix

- Qual foi a causa do bug?
  - Como a rota não estava pronta quando a modal foi desenvolvida, a requisição de rejeitar estava comentada e ao tentar fazê-la aparecia um snackbar de erro.
- O que foi feito para corrigi-lo?
  - Descomentar hook de requisição e atualiza o nome da rota para a que foi finalizada no backend.

# Setup

- [x] `yarn start`
- [x] Faça login como professor.

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Rejeitar monitoria

- [x] No sidebar, clique no botão "Solicitações".
- [x] Verifique que possui solicitações de monitoria pendentes.
- [x] Clique no botão de Recusar de uma delas e verifique que a modal de confirmar foi mostrada.
- [x] Clique no botão "Sim, recusar" e verifique se a monitoria foi recusada.
- [x] Feche a modal e verifique que a monitoria não está mais sendo mostrada.
