### PR TITLE
fix: Conserta erro da solicitação para ser monitor

### DIFF
--- a/src/components/addMonitorModal/hooks/useAddMonitorModal.ts
+++ b/src/components/addMonitorModal/hooks/useAddMonitorModal.ts
@@ -49,7 +49,7 @@ const useAddMonitorModal = () => {
   };
 
   const handleAddMonitorClick = () => {
-    addMonitor(user ? Number(user.sub) : -1, {
+    addMonitor({
       professor_id: selectedProfessorId,
       subject_id: selectedSubject?.id as number,
     });

--- a/src/service/requests/useAddMonitorRequest/index.ts
+++ b/src/service/requests/useAddMonitorRequest/index.ts
@@ -8,13 +8,13 @@ const useAddMonitorRequest = () => {
   const [error, setError] = useState<string>();
   const [isSuccess, setIsSuccess] = useState(false);
 
-  const addMonitor = async (studentId: number, body: TAddMonitorRequest) => {
+  const addMonitor = async (body: TAddMonitorRequest) => {
     setIsLoading(true);
     setIsSuccess(false);
     setError(undefined);
 
     try {
-      await api.post(`/monitor/request/${studentId}`, body);
+      await api.post(`/monitor/request/`, body);
 
       setIsSuccess(true);
     } catch (error) {


### PR DESCRIPTION
# Descrição

- Atualiza o hook da requisição AddMonitor

# Em casos de bugfix

- Qual foi a causa do bug?
  -  A função addMonitor recebia o parâmetro do Id do estudante e passava para a requisição 'monitor/request', mas isso não era necessário e impedia a requisição de ser concluída.
- O que foi feito para corrigi-lo?
  - Remoção do parametro studentId da função addMonitor

# Setup

- [ ] yarn start
- [ ] Fazer login como aluno

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Solicitar permissão para ser monitor**

- [ ] Na tela de disciplinas, clique em uma disciplina
- [ ] Clique em quero ser monitor
- [ ] Escolha um professor
- [ ] Clique em Enviar solicitação
