### PR TITLE
fix: Mostra apenas monitores disponíveis na disciplina

### DIFF
--- a/src/components/monitorAvailabilityModal/styles.ts
+++ b/src/components/monitorAvailabilityModal/styles.ts
@@ -1,4 +1,4 @@
-import { Typography, Chip, Switch, Modal, Select } from '@mui/material';
+import { Switch, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import styled from 'styled-components';
 import theme from '../../utils/theme';

--- a/src/components/termsConsentModal/index.tsx
+++ b/src/components/termsConsentModal/index.tsx
@@ -11,15 +11,10 @@ import {
 
 type Props = {
   isOpen: boolean;
-  handleOpenModal(): void;
   handleCloseModal(): void;
 };
 
-const TermConsentModal = ({
-  isOpen,
-  handleOpenModal,
-  handleCloseModal,
-}: Props) => {
+const TermConsentModal = ({ isOpen, handleCloseModal }: Props) => {
   const renderContent = () => {
     return (
       <TermConsentCard>

--- a/src/screens/registerProfessor/components/FormRegister/index.tsx
+++ b/src/screens/registerProfessor/components/FormRegister/index.tsx
@@ -171,7 +171,7 @@ const FormRegister = () => {
                     Ao clicar em “Finalizar”, você autoriza o recebimento de
                     notificações pelo e-mail IComp cadastrado na plataforma, bem
                     como Aceito os{' '}
-                    <TypographyGreen onClick={() => handleOpenModal()}>
+                    <TypographyGreen onClick={handleOpenModal}>
                       Termos de Consentimentos de Coleta de Dados e Política de
                       Privacidade.
                     </TypographyGreen>
@@ -187,7 +187,6 @@ const FormRegister = () => {
 
               <TermConsentModal
                 isOpen={isOpen}
-                handleOpenModal={handleOpenModal}
                 handleCloseModal={handleCloseModal}
               />
             </>

--- a/src/screens/registerStudent/components/FinalStudentRegister/index.tsx
+++ b/src/screens/registerStudent/components/FinalStudentRegister/index.tsx
@@ -114,7 +114,7 @@ const FinalStudentRegister = ({
             Ao clicar em “Finalizar”, você autoriza o recebimento de
             notificações pelo e-mail IComp cadastrado na plataforma, bem como
             Aceito os{' '}
-            <TypographyGreen onClick={() => handleOpenModal()}>
+            <TypographyGreen onClick={handleOpenModal}>
               Termos de Consentimentos de Coleta de Dados e Política de
               Privacidade.
             </TypographyGreen>
@@ -127,11 +127,7 @@ const FinalStudentRegister = ({
           <RightButton type="submit">Finalizar</RightButton>
         </ContainerContinue>
       </StyledForm>
-      <TermConsentModal
-        isOpen={isOpen}
-        handleOpenModal={handleOpenModal}
-        handleCloseModal={handleCloseModal}
-      />
+      <TermConsentModal isOpen={isOpen} handleCloseModal={handleCloseModal} />
     </>
   );
 };

--- a/src/screens/schedules/components/EventItem/styles.ts
+++ b/src/screens/schedules/components/EventItem/styles.ts
@@ -102,7 +102,8 @@ const scheduleStatusColor = {
   [SchedulesStatus.PENDING]: theme.palette.warning.main,
   [SchedulesStatus.CONFIRMED]: theme.palette.primary.main,
   [SchedulesStatus.CANCELED]: theme.palette.error.main,
-  [SchedulesStatus.OVERDUE]: theme.palette.error.main,
+  [SchedulesStatus.REALIZED]: theme.palette.error.main,
+  [SchedulesStatus.NOT_REALIZED]: theme.palette.error.main,
 };
 
 export const StatusIcon = styled(Box).attrs<StatusIconProps>((props) => ({

--- a/src/screens/subjectDetails/hooks/useSubjectDetails.ts
+++ b/src/screens/subjectDetails/hooks/useSubjectDetails.ts
@@ -6,7 +6,11 @@ import {
   TSubjectMonitor,
 } from '../../../service/requests/useGetSubject/types';
 import useGetLoggedUser from '../../../service/storage/getLoggedUser';
-import { TypeUserEnum, UserRole } from '../../../utils/constants';
+import {
+  TypeMonitoringStatus,
+  TypeUserEnum,
+  UserRole,
+} from '../../../utils/constants';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import { SCREENS } from '../../../utils/screens';
 
@@ -25,7 +29,10 @@ const useSubjectDetails = () => {
   const monitors = useMemo(() => {
     if (!subject) return [];
 
-    let filteredMonitors = subject.monitors;
+    let filteredMonitors = subject.monitors.filter(
+      (monitor) => monitor.status === TypeMonitoringStatus.AVAILABLE
+    );
+
     if (selectedProfessorId !== -1) {
       filteredMonitors = filteredMonitors.filter(
         (monitor) => monitor.responsable.id === selectedProfessorId

--- a/src/service/requests/useGetSubject/index.tsx
+++ b/src/service/requests/useGetSubject/index.tsx
@@ -1,5 +1,6 @@
 import { AxiosError } from 'axios';
 import { useState } from 'react';
+import { TypeMonitoringStatus } from '../../../utils/constants';
 import api from '../../api';
 import {
   TCompleteSubject,
@@ -34,6 +35,7 @@ const useGetSubject = () => {
           ...monitor.student.user,
           id: monitor.id,
           studentId: monitor.student.user.id,
+          status: monitor.status.status as TypeMonitoringStatus,
           course: monitor.student.course,
           responsable: monitor.responsible_professor.user,
         })),

--- a/src/service/requests/useGetSubject/types.ts
+++ b/src/service/requests/useGetSubject/types.ts
@@ -1,3 +1,4 @@
+import { TypeMonitoringStatus } from '../../../utils/constants';
 import { TSubject } from '../useListSubjectsRequest/types';
 
 export type TSubjectResponsible = {
@@ -11,6 +12,7 @@ export type TSubjectMonitor = {
   name: string;
   email: string;
   studentId?: number;
+  status?: TypeMonitoringStatus;
   responsable: {
     id: number;
     name: string;
@@ -60,6 +62,10 @@ export type TGetSubjectResponse = {
         id: number;
         name: string;
       };
+    };
+    status: {
+      id: number;
+      status: string;
     };
   }[];
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -38,14 +38,16 @@ export enum SchedulesStatus {
   PENDING = 1,
   CONFIRMED = 2,
   CANCELED = 3,
-  OVERDUE = 4,
+  REALIZED = 4,
+  NOT_REALIZED = 5,
 }
 
 export const ScheduleStatusTranslate = {
   [SchedulesStatus.PENDING]: 'Pendente',
   [SchedulesStatus.CONFIRMED]: 'Confirmado',
   [SchedulesStatus.CANCELED]: 'Cancelado',
-  [SchedulesStatus.OVERDUE]: 'Vencido',
+  [SchedulesStatus.REALIZED]: 'Realizada',
+  [SchedulesStatus.NOT_REALIZED]: 'Não realizada',
 };
 
 export enum SchedulesFilters {


### PR DESCRIPTION
# Descrição

Adiciona filtro na lista de monitores retornada na rota de detalhes de disciplina para sempre mostrar apenas os monitores cujo status é Disponível.

# Em casos de bugfix

- Qual foi a causa do bug?
  - A rota passou a retornar monitores disponíveis e confirmados, daí se tenta agendar com um confirmado vai ter um erro.
- O que foi feito para corrigi-lo?
  - Filtra o que vai mostrar na tela para apenas mostrar monitores disponíveis.

# Setup

- [ ] Use o backend de staging
- [ ] yarn start
- [ ] Faça login com a conta de um aluno

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Lista de monitores na disciplina 1

- [ ] Acesse página da disciplina 1
- [ ] Verifique que só estão listados monitores cujo status é disponível.
