### PR TITLE
Fix Redireciona para tela de Login quando o token expira

### DIFF
--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -27,8 +27,10 @@ api.interceptors.response.use(
     return response;
   },
   (error) => {
-    useClearStorage();
-    window.location.href = SCREENS.LOGIN;
+    if (error.response.status === 401) {
+      useClearStorage();
+      window.location.href = SCREENS.LOGIN;
+    }
     return Promise.reject(error);
   }
 );

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -2,7 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import useGetToken from '../storage/getToken';
 import useClearStorage from '../storage/clearStorage';
 import { SCREENS } from '../../utils/screens';
-import { NOTLOGGEDSCREENS } from '../../utils/screens';
+import { NOT_LOGGED_SCREENS } from '../../utils/screens';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_API_BASE_URL,
@@ -30,7 +30,7 @@ api.interceptors.response.use(
   (error) => {
     if (
       error.response.status === 401 &&
-      !NOTLOGGEDSCREENS.includes(window.location.pathname)
+      !NOT_LOGGED_SCREENS.includes(window.location.pathname)
     ) {
       alert(
         'Sua sessão expirou. Para continuar usando o Super Monitoria, faça login novamente.'

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import useGetToken from '../storage/getToken';
+import useClearStorage from '../storage/clearStorage';
+import { SCREENS } from '../../utils/screens';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_API_BASE_URL,
@@ -19,5 +21,16 @@ api.interceptors.request.use((config: AxiosRequestConfig) => {
 
   return config;
 });
+
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  (error) => {
+    useClearStorage();
+    window.location.href = SCREENS.LOGIN;
+    return Promise.reject(error);
+  }
+);
 
 export default api;

--- a/src/service/api/index.ts
+++ b/src/service/api/index.ts
@@ -2,6 +2,7 @@ import axios, { AxiosRequestConfig } from 'axios';
 import useGetToken from '../storage/getToken';
 import useClearStorage from '../storage/clearStorage';
 import { SCREENS } from '../../utils/screens';
+import { NOTLOGGEDSCREENS } from '../../utils/screens';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_API_BASE_URL,
@@ -27,7 +28,13 @@ api.interceptors.response.use(
     return response;
   },
   (error) => {
-    if (error.response.status === 401) {
+    if (
+      error.response.status === 401 &&
+      !NOTLOGGEDSCREENS.includes(window.location.pathname)
+    ) {
+      alert(
+        'Sua sessão expirou. Para continuar usando o Super Monitoria, faça login novamente.'
+      );
       useClearStorage();
       window.location.href = SCREENS.LOGIN;
     }

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -10,3 +10,11 @@ export const SCREENS = {
   SUBJECT_DETAILS: '/subjects/:id',
   MONITOR_REQUESTS: '/monitor-requests',
 };
+
+export const NOTLOGGEDSCREENS = [
+  '/code-verification',
+  '/',
+  '/register',
+  '/register/student',
+  '/register/professor',
+];

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -11,7 +11,7 @@ export const SCREENS = {
   MONITOR_REQUESTS: '/monitor-requests',
 };
 
-export const NOTLOGGEDSCREENS = [
+export const NOT_LOGGED_SCREENS = [
   '/code-verification',
   '/',
   '/register',


### PR DESCRIPTION
# Descrição

Adiciona um interceptor na response da api que limpa do storage local e redireciona para tela de login quando o token expira.

# Em casos de bugfix

- Qual foi a causa do bug?
- O backend retorna erro 401 quando o token de acesso expira, porém o frontend não estava lidando com esse comportamento.
- O que foi feito para corrigi-lo?
- Adição do interceptor na api do axios.

# Setup

- [ ] Use backend de staging
- [ ] yarn start
- [ ] Faça login com qualquer tipo de conta

# Cenários

## 1. Cenário A**

- [ ] Aguarde 2 horas até o tempo de expiração do token de acesso
- [ ] Acesse as das rotas do sistema logado. Ex: '/subjects'  , '/subectcs/1' ,  '/schedules'
- [ ] Verificar que é deslogado e redirecionado para a tela de login