### PR TITLE
feat: Tela de histórico de agendamentos

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "axios": "^1.1.3",
+    "dayjs": "^1.11.7",
     "jest-dom": "^4.0.0",
     "jest-mock-axios": "^4.7.0-beta",
     "jwt-decode": "^3.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import theme from './utils/theme';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterMoment } from '@mui/x-date-pickers/AdapterMoment';
 import 'moment/locale/pt';
+import SchedulesHistoric from './screens/schedulesHistoric';
 
 const App: React.FC = () => {
   return (
@@ -54,6 +55,11 @@ const App: React.FC = () => {
               <Route
                 path={SCREENS.MONITOR_REQUESTS}
                 element={<MonitorRequests />}
+              />
+
+              <Route
+                path={SCREENS.SCHEDULES_HISTORIC}
+                element={<SchedulesHistoric />}
               />
             </Routes>
           </BrowserRouter>

--- a/src/components/sidebar/hooks/useSidebar.ts
+++ b/src/components/sidebar/hooks/useSidebar.ts
@@ -3,6 +3,7 @@ import {
   GroupAddRounded,
   LogoutRounded,
   SchoolRounded,
+  HistoryRounded,
 } from '@mui/icons-material';
 import { useMediaQuery } from '@mui/material';
 import { useEffect, useMemo, useState } from 'react';
@@ -40,6 +41,15 @@ const useSidebar = () => {
     icon: SchoolRounded,
     handleClick: () => {
       navigate(SCREENS.SUBJECTS);
+    },
+  };
+
+  const schedulesHistoric: TSidebarItem = {
+    key: SidebarItemEnum.SCHEDULES_HISTORIC,
+    text: 'Histórico',
+    icon: HistoryRounded,
+    handleClick: () => {
+      navigate(SCREENS.SCHEDULES_HISTORIC);
     },
   };
 
@@ -85,7 +95,7 @@ const useSidebar = () => {
     if (user?.type_user_id === TypeUserEnum.STUDENT)
       return [subjectsItem, schedulesItem, logoutItem];
 
-    return [subjectsItem, monitorRequestsItem, logoutItem];
+    return [subjectsItem, monitorRequestsItem, schedulesHistoric, logoutItem];
   }, [user]);
 
   return {

--- a/src/screens/schedulesHistoric/components/DayEventItem/index.tsx
+++ b/src/screens/schedulesHistoric/components/DayEventItem/index.tsx
@@ -1,0 +1,39 @@
+import { Typography } from '@mui/material';
+import { TSchedules } from '../../../../service/requests/useGetSchedulesHistoricRequest/types';
+import theme from '../../../../utils/theme';
+import { TFormatedSchedules } from '../../hooks/types';
+import EventItem from '../EventItem';
+import { Container, DateContainer, EventsContainer } from './styles';
+
+type Props = {
+  dayEvent: TFormatedSchedules;
+  handleEventClick(schedule: TSchedules): void;
+};
+
+const DayEventItem = ({ dayEvent, handleEventClick }: Props) => {
+  const { day, weekDay, month, events } = dayEvent;
+
+  return (
+    <Container>
+      <DateContainer>
+        <Typography variant="subtitle1">{month}</Typography>
+        <Typography variant="h2">{day}</Typography>
+        <Typography variant="body2" color={theme.palette.grey[500]}>
+          {weekDay}
+        </Typography>
+      </DateContainer>
+
+      <EventsContainer>
+        {events.map((eventItem) => (
+          <EventItem
+            key={eventItem.id}
+            schedule={eventItem}
+            handleEventClick={handleEventClick}
+          />
+        ))}
+      </EventsContainer>
+    </Container>
+  );
+};
+
+export default DayEventItem;

--- a/src/screens/schedulesHistoric/components/DayEventItem/styles.ts
+++ b/src/screens/schedulesHistoric/components/DayEventItem/styles.ts
@@ -1,0 +1,33 @@
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../../../utils/theme';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'row',
+  gap: '24px',
+  width: '100%',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    gap: 16px !important;
+  }
+`;
+
+export const DateContainer = styled(Box).attrs({
+  display: 'flex',
+  alignItems: 'center',
+  flexDirection: 'column',
+  gap: '8px',
+  padding: '0 32px',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    padding: 0 8px !important;
+  }
+`;
+
+export const EventsContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '8px',
+  width: '100%',
+})``;

--- a/src/screens/schedulesHistoric/components/EventItem/index.tsx
+++ b/src/screens/schedulesHistoric/components/EventItem/index.tsx
@@ -1,0 +1,60 @@
+import { TSchedules } from '../../../../service/requests/useGetSchedulesHistoricRequest/types';
+import useGetLoggedUser from '../../../../service/storage/getLoggedUser';
+import { TypeUserEnum } from '../../../../utils/constants';
+import {
+  Container,
+  DataField,
+  EventDataContainer,
+  Label,
+  Value,
+} from './styles';
+
+type Props = {
+  schedule: TSchedules;
+  handleEventClick(schedule: TSchedules): void;
+};
+
+const EventItem = ({ schedule, handleEventClick }: Props) => {
+  const user = useGetLoggedUser();
+
+  const startTime = schedule.startDate.toTimeString().substring(0, 5);
+  const endTime = schedule.endDate.toTimeString().substring(0, 5);
+
+  return (
+    <Container onClick={() => handleEventClick(schedule)}>
+      <EventDataContainer>
+        <DataField>
+          <Label>Monitor(a)</Label>
+          <Value>{`${schedule.monitor.enrollment} - ${schedule.monitor.name}`}</Value>
+        </DataField>
+
+        <DataField>
+          <Label>Aluno(a)</Label>
+          <Value>{`${schedule.student.enrollment} - ${schedule.student.name}`}</Value>
+        </DataField>
+
+        <DataField>
+          <Label>Horário</Label>
+          <Value>
+            {startTime} até {endTime}
+          </Value>
+        </DataField>
+
+        <DataField>
+          {user?.type_user_id === TypeUserEnum.COORDINATOR ? (
+            <Label>Professor(a) Responsável</Label>
+          ) : (
+            <Label>Disciplina</Label>
+          )}
+          {user?.type_user_id === TypeUserEnum.COORDINATOR ? (
+            <Value>{schedule.responsibleProfessor.name}</Value>
+          ) : (
+            <Value>{schedule.subject.name}</Value>
+          )}
+        </DataField>
+      </EventDataContainer>
+    </Container>
+  );
+};
+
+export default EventItem;

--- a/src/screens/schedulesHistoric/components/EventItem/styles.ts
+++ b/src/screens/schedulesHistoric/components/EventItem/styles.ts
@@ -1,0 +1,121 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import { SchedulesStatus } from '../../../../utils/constants';
+import theme from '../../../../utils/theme';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  backgroundColor: theme.palette.background.default,
+  borderRadius: '16px',
+  width: '100%',
+})`
+  :hover {
+    cursor: pointer;
+    transition: 0.5s;
+    opacity: 0.7;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.xl}px) {
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+export const DataField = styled(Box).attrs({
+  margin: '8px',
+})`
+  @media (max-width: ${theme.breakpoints.values.xl}px) {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+interface EventTypeContainerProps {
+  monitor: boolean;
+}
+
+export const EventTypeContainer = styled(Box).attrs<EventTypeContainerProps>(
+  (props) => ({
+    backgroundColor: props.monitor
+      ? theme.palette.primary.main
+      : theme.palette.secondary.light,
+    borderRadius: '16px 0 0 16px',
+    minWidth: '140px',
+    padding: '16px',
+  })
+)<EventTypeContainerProps>`
+  & h6,
+  span {
+    color: white;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.xl}px) {
+    width: 100% !important;
+    border-radius: 16px 16px 0 0 !important;
+    padding: 0 !important;
+  }
+`;
+
+export const EventDataContainer = styled(Box).attrs({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(3, 1fr)',
+  width: '100%',
+  marginLeft: '16px',
+  padding: '16px 8px',
+})`
+  @media (max-width: ${theme.breakpoints.values.xl}px) {
+    display: flex !important;
+    flex-direction: column;
+    align-items: center;
+    width: 100% !important;
+    margin: 0 !important;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    padding: 16px 0 !important;
+  }
+`;
+
+export const Label = styled(Typography).attrs({
+  variant: 'caption',
+  color: theme.palette.secondary.light,
+})``;
+
+export const Value = styled(Typography).attrs({
+  variant: 'subtitle1',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    text-align: center !important;
+  }
+`;
+
+export const StatusValue = styled(Box).attrs({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+})``;
+
+interface StatusIconProps {
+  status: SchedulesStatus;
+  monitor: boolean;
+}
+
+const scheduleStatusColor = {
+  [SchedulesStatus.PENDING]: theme.palette.warning.main,
+  [SchedulesStatus.CONFIRMED]: theme.palette.primary.main,
+  [SchedulesStatus.CANCELED]: theme.palette.error.main,
+  [SchedulesStatus.OVERDUE]: theme.palette.error.main,
+};
+
+export const StatusIcon = styled(Box).attrs<StatusIconProps>((props) => ({
+  width: '16px',
+  minWidth: '16px',
+  height: '16px',
+  borderRadius: '16px',
+  backgroundColor:
+    !props.monitor && props.status === SchedulesStatus.PENDING
+      ? theme.palette.grey[400]
+      : scheduleStatusColor[props.status],
+}))<StatusIconProps>``;

--- a/src/screens/schedulesHistoric/components/EventList/index.tsx
+++ b/src/screens/schedulesHistoric/components/EventList/index.tsx
@@ -1,0 +1,76 @@
+import { Pagination, Typography } from '@mui/material';
+import LoadingAnimation from '../../../../components/loadingAnimation';
+import { TSchedules } from '../../../../service/requests/useGetSchedulesHistoricRequest/types';
+import theme from '../../../../utils/theme';
+import { TFormatedSchedules } from '../../hooks/types';
+import DayEventItem from '../DayEventItem';
+import { Container, FallbackContainer } from './styles';
+
+type Props = {
+  schedules: TFormatedSchedules[];
+  page: number;
+  isLoading: boolean;
+  totalPages: number;
+  error?: string;
+  handleEventClick(schedule: TSchedules): void;
+  handleChangePage(event: React.ChangeEvent<unknown>, page: number): void;
+};
+
+const EventList = ({
+  isLoading,
+  schedules,
+  page,
+  error,
+  totalPages,
+  handleEventClick,
+  handleChangePage,
+}: Props) => {
+  if (isLoading) {
+    return (
+      <FallbackContainer>
+        <LoadingAnimation />
+      </FallbackContainer>
+    );
+  }
+
+  if (!!error) {
+    return (
+      <FallbackContainer>
+        <Typography variant="body1" color={theme.palette.grey[500]}>
+          Ops... Tivemos um problema ao carregar os agendamentos. Tente
+          movamente mais tarde.
+        </Typography>
+      </FallbackContainer>
+    );
+  }
+
+  if (!schedules.length) {
+    return (
+      <FallbackContainer>
+        <Typography variant="body1" color={theme.palette.grey[500]}>
+          Hmm... Parece que não tem nenhum agendamento.
+        </Typography>
+      </FallbackContainer>
+    );
+  }
+
+  return (
+    <Container>
+      {schedules.map((dayEvents) => (
+        <DayEventItem
+          key={`${dayEvents.day}-${dayEvents.month}-${dayEvents.weekDay}`}
+          dayEvent={dayEvents}
+          handleEventClick={handleEventClick}
+        />
+      ))}
+      <Pagination
+        page={page}
+        onChange={handleChangePage}
+        count={totalPages}
+        color="primary"
+      />
+    </Container>
+  );
+};
+
+export default EventList;

--- a/src/screens/schedulesHistoric/components/EventList/styles.ts
+++ b/src/screens/schedulesHistoric/components/EventList/styles.ts
@@ -1,0 +1,18 @@
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '56px',
+  width: '100%',
+  marginTop: '36px',
+  alignItems: 'center',
+})``;
+
+export const FallbackContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  margin: '60px 0',
+})``;

--- a/src/screens/schedulesHistoric/components/FiltersForm/index.tsx
+++ b/src/screens/schedulesHistoric/components/FiltersForm/index.tsx
@@ -1,0 +1,185 @@
+import { makeStyles } from '@material-ui/core';
+import BookIcon from '@mui/icons-material/Book';
+import PersonIcon from '@mui/icons-material/Person';
+import SearchIcon from '@mui/icons-material/Search';
+import {
+  Box,
+  Chip,
+  InputAdornment,
+  MenuItem,
+  SelectChangeEvent,
+  Typography,
+} from '@mui/material';
+import { DesktopDatePicker } from '@mui/x-date-pickers';
+import { Dayjs } from 'dayjs';
+import { ReactNode } from 'react';
+import { Button } from '../../../../components/button';
+import { DateTextField } from '../../../../components/ScheduleHelpModal/components/FormScheduleModalContent/styles';
+import { TextField } from '../../../../components/textField';
+import { TProfessor } from '../../../../service/requests/useGetAllProfessors/types';
+import { TSubject } from '../../../../service/requests/useGetSchedulesHistoricRequest/types';
+import useGetLoggedUser from '../../../../service/storage/getLoggedUser';
+import { TypeUserEnum } from '../../../../utils/constants';
+import theme from '../../../../utils/theme';
+import { SelectField } from '../../../registerStudent/components/MiddleStudentRegister/styles';
+import { TScheduleHistoricFilters } from '../../hooks/types';
+import {
+  DatePickersContainer,
+  FilterButtonContainer,
+  LastFormRowContainer,
+  StyledForm,
+  UntilContainer,
+} from './styles';
+
+type Props = {
+  responseGetProfessorSubjects?: TSubject[];
+  responseGetAllProfessors?: TProfessor[];
+  filters: TScheduleHistoricFilters;
+  handleChangeNameOrEnrollFilter(e: React.ChangeEvent<HTMLInputElement>): void;
+  handleChangeResponsiblesOrSubjectsFilter(e: SelectChangeEvent<unknown>): void;
+  handleChangeBeginDateFilter(date: Dayjs | null): void;
+  handleChangeEndDateFilter(date: Dayjs | null): void;
+  handleFilterClick(e: React.SyntheticEvent<EventTarget>): void;
+};
+
+const FiltersForm = ({
+  responseGetProfessorSubjects,
+  responseGetAllProfessors,
+  filters,
+  handleChangeBeginDateFilter,
+  handleChangeEndDateFilter,
+  handleChangeResponsiblesOrSubjectsFilter,
+  handleChangeNameOrEnrollFilter,
+  handleFilterClick,
+}: Props) => {
+  const user = useGetLoggedUser();
+
+  interface PropsPlaceholder {
+    children?: ReactNode;
+  }
+
+  const usePlaceholderStyles = makeStyles(() => ({
+    placeholder: {
+      color: theme.palette.grey[500],
+    },
+  }));
+
+  const Placeholder = ({ children }: PropsPlaceholder) => {
+    const classes = usePlaceholderStyles();
+    return <div className={classes.placeholder}>{children}</div>;
+  };
+
+  const renderValues = (selected: string[]) => {
+    if (!filters.responsiblesOrSubjectsFilter?.length) {
+      if (user?.type_user_id === TypeUserEnum.PROFESSOR) {
+        return <Placeholder>Selecionar disciplina</Placeholder>;
+      }
+
+      return <Placeholder>Selecionar Professor</Placeholder>;
+    }
+
+    return (
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.5 }}>
+        {selected.map((value: string) => (
+          <Chip key={value.split(',')[1]} label={value.split(',')[1]} />
+        ))}
+      </Box>
+    );
+  };
+
+  return (
+    <Box sx={{ mt: '24px' }}>
+      <StyledForm>
+        <TextField
+          placeholder="Buscar nome ou matrícula"
+          value={filters.nameOrEnrollFilter}
+          onChange={handleChangeNameOrEnrollFilter}
+          startAdornment={
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          }
+        />
+        <SelectField
+          multiple
+          value={filters.responsiblesOrSubjectsFilter}
+          native={false}
+          displayEmpty={true}
+          onChange={handleChangeResponsiblesOrSubjectsFilter}
+          startAdornment={
+            <InputAdornment position="start">
+              {user?.type_user_id === TypeUserEnum.PROFESSOR ? (
+                <BookIcon />
+              ) : (
+                <PersonIcon />
+              )}
+            </InputAdornment>
+          }
+          renderValue={(selected) => renderValues(selected as string[])}
+        >
+          {user?.type_user_id === TypeUserEnum.PROFESSOR
+            ? responseGetProfessorSubjects?.map((sub) => (
+                <MenuItem key={sub.id} value={`${sub.id},${sub.name}`}>
+                  {sub.name}
+                </MenuItem>
+              ))
+            : responseGetAllProfessors?.map((prof) => (
+                <MenuItem
+                  key={prof.user.id}
+                  value={`${prof.user.id},${prof.user.name}`}
+                >
+                  {prof.user.name}
+                </MenuItem>
+              ))}
+        </SelectField>
+        <LastFormRowContainer>
+          <DatePickersContainer>
+            <DesktopDatePicker
+              inputFormat="DD/MM/YYYY"
+              value={filters.beginDateFilter}
+              onChange={handleChangeBeginDateFilter}
+              renderInput={(params) => (
+                <DateTextField
+                  {...params}
+                  inputProps={{
+                    ...params.inputProps,
+                    placeholder: 'Data Início',
+                  }}
+                />
+              )}
+            />
+            <UntilContainer>
+              <Typography variant="body1">até</Typography>
+            </UntilContainer>
+            <DesktopDatePicker
+              inputFormat="DD/MM/YYYY"
+              value={filters.endDateFilter}
+              onChange={handleChangeEndDateFilter}
+              renderInput={(params) => (
+                <DateTextField
+                  {...params}
+                  inputProps={{
+                    ...params.inputProps,
+                    placeholder: 'Data Final',
+                  }}
+                />
+              )}
+            />
+          </DatePickersContainer>
+          <FilterButtonContainer>
+            <Button
+              sx={{ width: '100%' }}
+              color="primary"
+              onClick={handleFilterClick}
+              type="submit"
+            >
+              Filtrar
+            </Button>
+          </FilterButtonContainer>
+        </LastFormRowContainer>
+      </StyledForm>
+    </Box>
+  );
+};
+
+export default FiltersForm;

--- a/src/screens/schedulesHistoric/components/FiltersForm/styles.ts
+++ b/src/screens/schedulesHistoric/components/FiltersForm/styles.ts
@@ -1,0 +1,55 @@
+import { Box, Select } from '@mui/material';
+import styled from 'styled-components';
+import theme from '../../../../utils/theme';
+
+export const StyledForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100% !important;
+`;
+
+export const SelectField = styled(Select)`
+  width: 100% !important;
+  fieldset {
+    border-radius: 12px;
+  }
+`;
+
+export const DatePickersContainer = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'row',
+  alignItems: 'center',
+  gap: '16px',
+  width: '90%',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    flex-direction: column !important;
+    width: 100% !important;
+  }
+`;
+
+export const FilterButtonContainer = styled(Box).attrs({
+  width: '20%',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+  }
+`;
+
+export const UntilContainer = styled(Box)`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    display: none !important;
+  }
+`;
+
+export const LastFormRowContainer = styled(Box)`
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  align-items: center;
+  width: 100%;
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    flex-direction: column;
+  }
+`;

--- a/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
@@ -1,0 +1,34 @@
+import Modal from '../../../../components/modal';
+import { TSchedules } from '../../../../service/requests/useGetSchedulesHistoricRequest/types';
+import ScheduleHistoricModal from '../ScheduleHistoricModalContent';
+
+type Props = {
+  schedule?: TSchedules;
+  isOpen: boolean;
+  handleClose(): void;
+};
+
+const ScheduleDetailsModal = ({ schedule, isOpen, handleClose }: Props) => {
+  if (!schedule) return <></>;
+
+  const startTime = schedule.startDate.toTimeString().substring(0, 5);
+  const endTime = schedule.endDate.toTimeString().substring(0, 5);
+  const date = schedule.startDate.toLocaleDateString('pt-br');
+
+  return (
+    <Modal width="550px" isOpen={isOpen} handleClose={handleClose}>
+      <ScheduleHistoricModal
+        student={`${schedule.student.enrollment} - ${schedule.student.name}`}
+        course={schedule.subject.course.name}
+        subject={schedule.subject.name}
+        monitor={`${schedule.monitor.enrollment} - ${schedule.monitor.name}`}
+        professor={schedule.responsibleProfessor.name}
+        date={date}
+        schedule={`${startTime} até ${endTime}`}
+        handleClose={handleClose}
+      />
+    </Modal>
+  );
+};
+
+export default ScheduleDetailsModal;

--- a/src/screens/schedulesHistoric/components/ScheduleDetailsModal/styles.ts
+++ b/src/screens/schedulesHistoric/components/ScheduleDetailsModal/styles.ts
@@ -1,0 +1,38 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../../../utils/theme';
+
+export const DataContainer = styled(Box).attrs({
+  display: 'grid',
+  gridTemplateColumns: '1fr 3fr',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    grid-template-columns: 1fr 2fr !important;
+  }
+`;
+
+export const ButtonContainer = styled(Box).attrs({
+  display: 'flex',
+  width: '100%',
+  justifyContent: 'center',
+})``;
+
+export const ButtonsContainer = styled(Box).attrs({
+  display: 'flex',
+  width: '100%',
+  justifyContent: 'space-around',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    flex-direction: column-reverse;
+    justify-content: center !important;
+    align-items: center !important;
+    gap: 16px;
+  }
+`;
+
+export const Label = styled(Typography).attrs({
+  variant: 'body2',
+})`
+  color: ${theme.palette.grey[600]} !important;
+`;

--- a/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
@@ -1,0 +1,79 @@
+import { Typography } from '@mui/material';
+import { Button } from '../../../../components/button';
+import {
+  ButtonContainer,
+  DataContainer,
+  Label,
+} from '../ScheduleDetailsModal/styles';
+
+type Props = {
+  student: string;
+  course: string;
+  subject: string;
+  monitor: string;
+  professor: string;
+  date: string;
+  schedule: string;
+  handleClose(): void;
+};
+
+const ScheduleHistoricModal = ({
+  course,
+  date,
+  monitor,
+  professor,
+  schedule,
+  student,
+  subject,
+  handleClose,
+}: Props) => (
+  <>
+    <Typography variant="h4">Detalhes do Agendamento</Typography>
+    <Typography variant="body1">
+      Aqui você poderá visualizar mais informações sobre a monitoria realizada
+    </Typography>
+
+    <DataContainer>
+      <Label>Aluno(a)</Label>
+      <Typography variant="body2">{student}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Curso</Label>
+      <Typography variant="body2">{course}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Disciplina</Label>
+      <Typography variant="body2">{subject}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Monitor(a)</Label>
+      <Typography variant="body2">{monitor}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Professora(a)</Label>
+      <Typography variant="body2">{professor}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Data</Label>
+      <Typography variant="body2">{date}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Horário</Label>
+      <Typography variant="body2">{schedule}</Typography>
+    </DataContainer>
+
+    <ButtonContainer>
+      <Button variant="text" color="primary" onClick={handleClose}>
+        Fechar
+      </Button>
+    </ButtonContainer>
+  </>
+);
+
+export default ScheduleHistoricModal;

--- a/src/screens/schedulesHistoric/hooks/types.ts
+++ b/src/screens/schedulesHistoric/hooks/types.ts
@@ -1,0 +1,23 @@
+import { Dayjs } from 'dayjs';
+import { TSchedules } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
+
+export type TFormatedSchedules = {
+  month: string;
+  day: number;
+  weekDay: string;
+  events: TSchedules[];
+};
+
+export type TSchedulesHistoricFilters = {
+  month: string;
+  day: number;
+  weekDay: string;
+  events: TSchedules[];
+};
+
+export type TScheduleHistoricFilters = {
+  nameOrEnrollFilter: string;
+  responsiblesOrSubjectsFilter: string[];
+  beginDateFilter: Dayjs | null;
+  endDateFilter: Dayjs | null;
+};

--- a/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
+++ b/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
@@ -1,0 +1,181 @@
+import { SelectChangeEvent } from '@mui/material';
+import { Dayjs } from 'dayjs';
+import { useEffect, useState } from 'react';
+import useGetAllProfessors from '../../../service/requests/useGetAllProfessors';
+import useGetProfessorSubjects from '../../../service/requests/useGetProfessorSubjects';
+import { TGetSchedulesHistoricRequestParams } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
+import useGetLoggedUser from '../../../service/storage/getLoggedUser';
+import { TypeUserEnum } from '../../../utils/constants';
+import { useSnackBar } from '../../../utils/renderSnackBar';
+import { TScheduleHistoricFilters } from './types';
+
+type Props = {
+  getSchedules(params: TGetSchedulesHistoricRequestParams): void;
+  setPage(page: React.SetStateAction<number>): void;
+};
+
+const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
+  const { showErrorSnackBar } = useSnackBar();
+
+  const user = useGetLoggedUser();
+
+  const {
+    error: errorGetProfessorSubjects,
+    getProfessorSubjects,
+    isLoading: isLoadingGetProfessorSubjects,
+    response: responseGetProfessorSubjects,
+  } = useGetProfessorSubjects();
+
+  const {
+    error: errorGetAllProfessors,
+    getProfessors,
+    isLoading: isLoadingGetAllProfessors,
+    response: responseGetAllProfessors,
+  } = useGetAllProfessors();
+
+  const [filters, setFilters] = useState<TScheduleHistoricFilters>({
+    nameOrEnrollFilter: '',
+    beginDateFilter: null,
+    endDateFilter: null,
+    responsiblesOrSubjectsFilter: [],
+  });
+
+  const handleFiltersChange = (filters: TScheduleHistoricFilters) => {
+    setFilters(filters);
+  };
+
+  const handleChangeBeginDateFilter = (date: Dayjs | null) => {
+    const currentFilters: TScheduleHistoricFilters = {
+      nameOrEnrollFilter: filters.nameOrEnrollFilter,
+      beginDateFilter: date,
+      endDateFilter: filters.endDateFilter,
+      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
+    };
+
+    handleFiltersChange(currentFilters);
+  };
+
+  const handleChangeEndDateFilter = (date: Dayjs | null) => {
+    const currentFilters: TScheduleHistoricFilters = {
+      nameOrEnrollFilter: filters.nameOrEnrollFilter,
+      beginDateFilter: filters.beginDateFilter,
+      endDateFilter: date,
+      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
+    };
+
+    handleFiltersChange(currentFilters);
+  };
+
+  const handleChangeResponsiblesOrSubjectsFilter = (
+    e: SelectChangeEvent<typeof responsiblesOrSubjectsFilter>
+  ) => {
+    const value = e.target.value as string;
+
+    const responsiblesOrSubjectsFilter =
+      typeof value === 'string' ? value.split(' ') : value;
+
+    const currentFilters: TScheduleHistoricFilters = {
+      nameOrEnrollFilter: filters.nameOrEnrollFilter,
+      beginDateFilter: filters.beginDateFilter,
+      endDateFilter: filters.endDateFilter,
+      responsiblesOrSubjectsFilter: responsiblesOrSubjectsFilter,
+    };
+
+    handleFiltersChange(currentFilters);
+  };
+
+  const handleChangeNameOrEnrollFilter = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const currentFilters: TScheduleHistoricFilters = {
+      nameOrEnrollFilter: e.target.value,
+      beginDateFilter: filters.beginDateFilter,
+      endDateFilter: filters.endDateFilter,
+      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
+    };
+
+    handleFiltersChange(currentFilters);
+  };
+
+  const getNameAndEnrollment = (str: string) => {
+    if (!str.length)
+      return {
+        name: '',
+        enrollment: '',
+      };
+    else if (!Number.isNaN(parseInt(String(str))))
+      return {
+        name: '',
+        enrollment: parseInt(String(str)),
+      };
+
+    return {
+      name: str,
+      enrollment: '',
+    };
+  };
+
+  const handleFilterClick = (e: React.SyntheticEvent<EventTarget>) => {
+    e.preventDefault();
+
+    const getValues = getNameAndEnrollment(filters.nameOrEnrollFilter);
+
+    const formatedFilters: TGetSchedulesHistoricRequestParams = {
+      page: 1,
+      endDate: filters.endDateFilter?.toDate(),
+      startDate: filters.beginDateFilter?.toDate(),
+      studentName: getValues.name,
+      studentEnrollment: getValues.enrollment.toString(),
+    } as TGetSchedulesHistoricRequestParams;
+
+    const ids = filters.responsiblesOrSubjectsFilter.map((attr) =>
+      parseInt(attr.split(',')[0])
+    );
+
+    user?.type_user_id === TypeUserEnum.COORDINATOR
+      ? (formatedFilters.responsibleIds = ids)
+      : (formatedFilters.subjectIds = ids);
+
+    void getSchedules(formatedFilters);
+
+    setPage(1);
+  };
+
+  useEffect(() => {
+    user?.type_user_id === TypeUserEnum.PROFESSOR
+      ? void getProfessorSubjects(parseInt(user.sub))
+      : void getProfessors();
+  }, []);
+
+  useEffect(() => {
+    if (errorGetAllProfessors) {
+      showErrorSnackBar(
+        'Erro ao carregar a lista de professores! Tente novamente mais tarde'
+      );
+    }
+  }, [errorGetAllProfessors]);
+
+  useEffect(() => {
+    if (errorGetProfessorSubjects) {
+      showErrorSnackBar(
+        'Erro ao carregar a lista de disciplinas! Tente novamente mais tarde'
+      );
+    }
+  }, [errorGetProfessorSubjects]);
+
+  return {
+    responseGetProfessorSubjects,
+    responseGetAllProfessors,
+    isLoadingGetProfessorSubjects,
+    isLoadingGetAllProfessors,
+    getNameAndEnrollment,
+    filters,
+    handleChangeBeginDateFilter,
+    handleChangeEndDateFilter,
+    handleFilterClick,
+    handleChangeNameOrEnrollFilter,
+    handleChangeResponsiblesOrSubjectsFilter,
+  };
+};
+
+export default useSchedulesHistoric;

--- a/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
+++ b/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
@@ -46,10 +46,8 @@ const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
 
   const handleChangeBeginDateFilter = (date: Dayjs | null) => {
     const currentFilters: TScheduleHistoricFilters = {
-      nameOrEnrollFilter: filters.nameOrEnrollFilter,
+      ...filters,
       beginDateFilter: date,
-      endDateFilter: filters.endDateFilter,
-      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
     };
 
     handleFiltersChange(currentFilters);
@@ -57,10 +55,8 @@ const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
 
   const handleChangeEndDateFilter = (date: Dayjs | null) => {
     const currentFilters: TScheduleHistoricFilters = {
-      nameOrEnrollFilter: filters.nameOrEnrollFilter,
-      beginDateFilter: filters.beginDateFilter,
+      ...filters,
       endDateFilter: date,
-      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
     };
 
     handleFiltersChange(currentFilters);
@@ -75,9 +71,7 @@ const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
       typeof value === 'string' ? value.split(' ') : value;
 
     const currentFilters: TScheduleHistoricFilters = {
-      nameOrEnrollFilter: filters.nameOrEnrollFilter,
-      beginDateFilter: filters.beginDateFilter,
-      endDateFilter: filters.endDateFilter,
+      ...filters,
       responsiblesOrSubjectsFilter: responsiblesOrSubjectsFilter,
     };
 
@@ -88,10 +82,8 @@ const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const currentFilters: TScheduleHistoricFilters = {
+      ...filters,
       nameOrEnrollFilter: e.target.value,
-      beginDateFilter: filters.beginDateFilter,
-      endDateFilter: filters.endDateFilter,
-      responsiblesOrSubjectsFilter: filters.responsiblesOrSubjectsFilter,
     };
 
     handleFiltersChange(currentFilters);

--- a/src/screens/schedulesHistoric/hooks/useFormatSchedules.ts
+++ b/src/screens/schedulesHistoric/hooks/useFormatSchedules.ts
@@ -1,0 +1,66 @@
+import { useMemo } from 'react';
+import {
+  TSchedules,
+  TGetSchedulesHistoricRequestResponse,
+} from '../../../service/requests/useGetSchedulesHistoricRequest/types';
+
+import { TFormatedSchedules } from './types';
+
+const useFormatSchedules = (
+  response?: TGetSchedulesHistoricRequestResponse
+) => {
+  const formatDateType = (schedule: TSchedules) => ({
+    ...schedule,
+    startDate: new Date(schedule.startDate),
+    endDate: new Date(schedule.endDate),
+  });
+
+  const groupSchedulesByDate = (
+    groups: Map<string, TSchedules[]>,
+    schedule: TSchedules
+  ) => {
+    const scheduleGroup = schedule.startDate.toLocaleDateString('pt-BR', {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+    });
+    const groupsSchedules = [...(groups.get(scheduleGroup) || []), schedule];
+    groups.set(scheduleGroup, groupsSchedules);
+    return groups;
+  };
+
+  const capitalize = (word?: string) =>
+    word ? word.charAt(0).toUpperCase() + word.slice(1) : '';
+
+  const schedules: TFormatedSchedules[] = useMemo(() => {
+    if (!response?.data?.length) return [];
+
+    const data = response.data.map(formatDateType);
+
+    const schedulesGroupMap = data.reduce(
+      groupSchedulesByDate,
+      new Map<string, TSchedules[]>()
+    );
+
+    const formatedSchedules: TFormatedSchedules[] = [];
+    schedulesGroupMap.forEach((value, key) => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const [weekDay, day, prep, month] = key.split(' ');
+
+      formatedSchedules.push({
+        day: Number(day),
+        weekDay: capitalize(weekDay.split('-')[0]),
+        month: capitalize(month),
+        events: value,
+      });
+    });
+
+    return formatedSchedules;
+  }, [response]);
+
+  return {
+    schedules,
+  };
+};
+
+export default useFormatSchedules;

--- a/src/screens/schedulesHistoric/hooks/useScheduleDetailsModal.ts
+++ b/src/screens/schedulesHistoric/hooks/useScheduleDetailsModal.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+import { TSchedules } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
+
+const useScheduleDetailsModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedSchedule, setSelectedSchedule] = useState<TSchedules>();
+
+  const handleClose = () => {
+    setSelectedSchedule(undefined);
+    setIsOpen(false);
+  };
+
+  const handleOpen = (schedule: TSchedules) => {
+    setSelectedSchedule(schedule);
+    setIsOpen(true);
+  };
+
+  return {
+    selectedSchedule,
+    isOpen,
+    handleClose,
+    handleOpen,
+  };
+};
+
+export default useScheduleDetailsModal;

--- a/src/screens/schedulesHistoric/hooks/useSchedulesHistoric.ts
+++ b/src/screens/schedulesHistoric/hooks/useSchedulesHistoric.ts
@@ -1,0 +1,111 @@
+import { useEffect, useMemo, useState } from 'react';
+import useGetSchedulesHistoricRequest from '../../../service/requests/useGetSchedulesHistoricRequest';
+import { TGetSchedulesHistoricRequestParams } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
+import useGetLoggedUser from '../../../service/storage/getLoggedUser';
+import { TypeUserEnum } from '../../../utils/constants';
+import { useSnackBar } from '../../../utils/renderSnackBar';
+import useFiltersForm from './useFiltersForm';
+import useFormatSchedules from './useFormatSchedules';
+import useScheduleDetailsModal from './useScheduleDetailsModal';
+
+const useSchedulesHistoric = () => {
+  const user = useGetLoggedUser();
+
+  const { showErrorSnackBar } = useSnackBar();
+
+  const { response, error, getSchedules, isLoading } =
+    useGetSchedulesHistoricRequest();
+
+  const { schedules } = useFormatSchedules(response);
+
+  const [page, setPage] = useState(1);
+
+  const totalPages = useMemo(() => response?.meta.totalPages || 0, [response]);
+
+  const {
+    isLoadingGetAllProfessors,
+    isLoadingGetProfessorSubjects,
+    responseGetProfessorSubjects,
+    responseGetAllProfessors,
+    filters,
+    handleChangeBeginDateFilter,
+    handleChangeEndDateFilter,
+    handleChangeNameOrEnrollFilter,
+    handleChangeResponsiblesOrSubjectsFilter,
+    handleFilterClick,
+    getNameAndEnrollment,
+  } = useFiltersForm({ getSchedules, setPage });
+
+  const {
+    isOpen: isScheduleDetailsModalOpen,
+    handleOpen: handleEventClick,
+    handleClose: handleCloseScheduleDetailsModal,
+    selectedSchedule,
+  } = useScheduleDetailsModal();
+
+  const handleChangePage = (
+    event: React.ChangeEvent<unknown>,
+    newPage: number
+  ) => {
+    if (newPage === page) return;
+
+    const getValues = getNameAndEnrollment(filters.nameOrEnrollFilter);
+
+    const formatedFilters: TGetSchedulesHistoricRequestParams = {
+      page: newPage,
+      endDate: filters.endDateFilter?.toDate(),
+      startDate: filters.beginDateFilter?.toDate(),
+      studentName: getValues.name,
+      studentEnrollment: getValues.enrollment.toString(),
+    } as TGetSchedulesHistoricRequestParams;
+
+    const ids = filters.responsiblesOrSubjectsFilter.map((attr) =>
+      parseInt(attr.split(',')[0])
+    );
+
+    user?.type_user_id === TypeUserEnum.COORDINATOR
+      ? (formatedFilters.responsibleIds = ids)
+      : (formatedFilters.subjectIds = ids);
+
+    void getSchedules(formatedFilters);
+
+    setPage(newPage);
+  };
+
+  useEffect(() => {
+    document.title = 'Histórico de Agendamentos';
+
+    void getSchedules({ page });
+  }, []);
+
+  useEffect(() => {
+    if (!error) return;
+
+    showErrorSnackBar(`Erro ao carregar agendamentos: ${error}`);
+  }, [error]);
+
+  return {
+    responseGetProfessorSubjects,
+    responseGetAllProfessors,
+    isScheduleDetailsModalOpen,
+    schedules,
+    page,
+    selectedSchedule,
+    error,
+    totalPages,
+    isLoading,
+    isLoadingGetAllProfessors,
+    isLoadingGetProfessorSubjects,
+    filters,
+    handleChangeBeginDateFilter,
+    handleChangeEndDateFilter,
+    handleChangeNameOrEnrollFilter,
+    handleChangeResponsiblesOrSubjectsFilter,
+    handleFilterClick,
+    handleEventClick,
+    handleChangePage,
+    handleCloseScheduleDetailsModal,
+  };
+};
+
+export default useSchedulesHistoric;

--- a/src/screens/schedulesHistoric/index.tsx
+++ b/src/screens/schedulesHistoric/index.tsx
@@ -1,0 +1,76 @@
+import { Typography } from '@mui/material';
+import ContainerWithSidebar from '../../components/containerWithSidebar';
+import { SidebarItemEnum } from '../../utils/constants';
+import EventList from './components/EventList';
+import FiltersForm from './components/FiltersForm';
+import ScheduleDetailsModal from './components/ScheduleDetailsModal';
+import useSchedulesHistoric from './hooks/useSchedulesHistoric';
+import { Card, Container, LegendTypography } from './styles';
+
+const SchedulesHistoric = () => {
+  const {
+    isScheduleDetailsModalOpen,
+    handleFilterClick,
+    handleChangeResponsiblesOrSubjectsFilter,
+    handleEventClick,
+    schedules,
+    handleChangeNameOrEnrollFilter,
+    selectedSchedule,
+    isLoading,
+    error,
+    page,
+    handleChangePage,
+    totalPages,
+    handleCloseScheduleDetailsModal,
+    filters,
+    handleChangeBeginDateFilter,
+    handleChangeEndDateFilter,
+    responseGetAllProfessors,
+    responseGetProfessorSubjects,
+  } = useSchedulesHistoric();
+
+  return (
+    <ContainerWithSidebar
+      selectedSidebarItem={SidebarItemEnum.SCHEDULES_HISTORIC}
+    >
+      <ScheduleDetailsModal
+        schedule={selectedSchedule}
+        isOpen={isScheduleDetailsModalOpen}
+        handleClose={handleCloseScheduleDetailsModal}
+      />
+      <Container>
+        <Card>
+          <Typography variant="h3">Histórico de Agendamentos</Typography>
+          <LegendTypography>
+            Aqui você encontra todos os agendamentos realizados organizados do
+            mais recente ao mais antigo. Clique em um evento para ver mais
+            detalhes.
+          </LegendTypography>
+          <FiltersForm
+            filters={filters}
+            handleFilterClick={handleFilterClick}
+            responseGetAllProfessors={responseGetAllProfessors}
+            responseGetProfessorSubjects={responseGetProfessorSubjects}
+            handleChangeBeginDateFilter={handleChangeBeginDateFilter}
+            handleChangeEndDateFilter={handleChangeEndDateFilter}
+            handleChangeNameOrEnrollFilter={handleChangeNameOrEnrollFilter}
+            handleChangeResponsiblesOrSubjectsFilter={
+              handleChangeResponsiblesOrSubjectsFilter
+            }
+          />
+          <EventList
+            isLoading={isLoading}
+            schedules={schedules}
+            handleEventClick={handleEventClick}
+            page={page}
+            error={error}
+            handleChangePage={handleChangePage}
+            totalPages={totalPages}
+          />
+        </Card>
+      </Container>
+    </ContainerWithSidebar>
+  );
+};
+
+export default SchedulesHistoric;

--- a/src/screens/schedulesHistoric/styles.ts
+++ b/src/screens/schedulesHistoric/styles.ts
@@ -1,0 +1,53 @@
+import { Typography } from '@mui/material';
+import { Box } from '@mui/system';
+import styled from 'styled-components';
+import theme from '../../utils/theme';
+
+export const Container = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+})`
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    margin: 0 16px !important;
+  }
+`;
+
+export const FallbackTypography = styled(Typography).attrs({
+  textAlign: 'center',
+})`
+  color: ${theme.palette.grey[500]} !important;
+`;
+
+export const Card = styled(Box).attrs({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: '32px',
+  width: '1128px',
+  margin: '24px',
+  backgroundColor: 'white',
+})`
+  border-radius: 24px;
+  box-shadow: 0px 0px 12px rgba(0, 0, 0, 0.1);
+
+  @media (max-width: ${theme.breakpoints.values.md}px) {
+    width: 100% !important;
+  }
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    width: 100% !important;
+    padding: 0 !important;
+    margin: 16px 0 !important;
+    box-shadow: none;
+  }
+`;
+
+export const LegendTypography = styled(Typography).attrs({
+  color: 'secondary',
+  variant: 'body2',
+})`
+  margin-top: 8px !important;
+
+  @media (max-width: ${theme.breakpoints.values.sm}px) {
+    margin-top: 16px !important;
+  }
+`;

--- a/src/service/requests/useGetAllProfessors/index.ts
+++ b/src/service/requests/useGetAllProfessors/index.ts
@@ -1,0 +1,41 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import { TProfessor, TGetProfessorsErrorResponse } from './types';
+
+const useGetAllProfessors = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [response, setData] = useState<TProfessor[]>();
+
+  const getProfessors = async () => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    try {
+      const response = await api.get(`/teacher?quantity=100`);
+
+      setData(response.data.data as TProfessor[]);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TGetProfessorsErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during professors request. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    response,
+    error,
+    getProfessors,
+  };
+};
+
+export default useGetAllProfessors;

--- a/src/service/requests/useGetAllProfessors/types.ts
+++ b/src/service/requests/useGetAllProfessors/types.ts
@@ -1,0 +1,32 @@
+export type TStatus = {
+  id: number;
+  status: string;
+};
+
+export type TSubject = {
+  name: string;
+  code: string;
+};
+
+export type TUser = {
+  id: number;
+  name: string;
+  email: string;
+  is_verified: boolean;
+};
+
+export type TSubjectResponsability = {
+  status: TStatus;
+  subject: TSubject;
+};
+
+export type TProfessor = {
+  user: TUser;
+  SubjectResponsability: TSubjectResponsability;
+};
+
+export type TGetProfessorsErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};

--- a/src/service/requests/useGetProfessorSubjects/index.ts
+++ b/src/service/requests/useGetProfessorSubjects/index.ts
@@ -1,0 +1,42 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import { TGetProfessorSubjectsErrorResponse, TSubject } from './types';
+
+const useGetSchedulesHistoricRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [response, setData] = useState<TSubject[]>();
+
+  const getProfessorSubjects = async (id: number) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    try {
+      const response = await api.get(`/teacher/${id}/subjects`);
+
+      setData(response.data.data as TSubject[]);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response
+        ?.data as TGetProfessorSubjectsErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during subjects request. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    response,
+    error,
+    getProfessorSubjects,
+  };
+};
+
+export default useGetSchedulesHistoricRequest;

--- a/src/service/requests/useGetProfessorSubjects/types.ts
+++ b/src/service/requests/useGetProfessorSubjects/types.ts
@@ -1,0 +1,18 @@
+export type TCourse = {
+  id: number;
+  name: string;
+  code: string;
+};
+
+export type TSubject = {
+  id: number;
+  code: string;
+  name: string;
+  course: TCourse;
+};
+
+export type TGetProfessorSubjectsErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};

--- a/src/service/requests/useGetSchedulesHistoricRequest/index.tsx
+++ b/src/service/requests/useGetSchedulesHistoricRequest/index.tsx
@@ -1,0 +1,76 @@
+import { AxiosError } from 'axios';
+import moment from 'moment';
+import { useState } from 'react';
+import { SchedulesStatus } from '../../../utils/constants';
+import api from '../../api';
+import {
+  TGetSchedulesHistoricErrorResponse,
+  TGetSchedulesHistoricRequestParams,
+  TGetSchedulesHistoricRequestResponse,
+} from './types';
+
+const useGetSchedulesHistoricRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [response, setData] = useState<TGetSchedulesHistoricRequestResponse>();
+
+  const getSchedules = async ({
+    page,
+    startDate,
+    endDate,
+    responsibleIds,
+    studentEnrollment,
+    studentName,
+    subjectIds,
+  }: TGetSchedulesHistoricRequestParams) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    const subjectIdsString = subjectIds
+      ?.map((id) => `&subjectIds=${id}`)
+      .join('');
+
+    const responsibleIdsString = responsibleIds
+      ?.map((id) => `&responsibleIds=${id}`)
+      .join('');
+
+    try {
+      const response = await api.get(
+        `/schedules?pageSize=10&page=${page || 1}&status=${
+          SchedulesStatus.CONFIRMED
+        }${
+          startDate
+            ? `&startDate=` + moment(startDate).format('YYYY-MM-DD')
+            : ``
+        }${endDate ? `&endDate=` + moment(endDate).format('YYYY-MM-DD') : ``}${
+          subjectIds ? subjectIdsString : ``
+        }${responsibleIds ? responsibleIdsString : ``}${
+          studentEnrollment ? `&studentEnrollment=` + studentEnrollment : ``
+        }${studentName ? `&studentName=` + studentName : ``}`
+      );
+
+      setData(response.data as TGetSchedulesHistoricRequestResponse);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response
+        ?.data as TGetSchedulesHistoricErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during schedules request. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    response,
+    error,
+    getSchedules,
+  };
+};
+
+export default useGetSchedulesHistoricRequest;

--- a/src/service/requests/useGetSchedulesHistoricRequest/types.ts
+++ b/src/service/requests/useGetSchedulesHistoricRequest/types.ts
@@ -1,0 +1,73 @@
+export type TCourse = {
+  id: number;
+  name: string;
+};
+
+export type TGetSchedulesHistoricErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};
+
+export type TStudent = {
+  id: number;
+  enrollment: string;
+  name: string;
+  email: string;
+};
+
+export type TSubject = {
+  id: number;
+  name: string;
+  course: TCourse;
+};
+
+export type TMonitor = {
+  id: number;
+  userId: number;
+  enrollment: string;
+  name: string;
+  email: string;
+};
+
+export type TResponsibleProfessor = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export type TSchedules = {
+  id: number;
+  startDate: Date;
+  endDate: Date;
+  status: number;
+  monitor: TMonitor;
+  student: TStudent;
+  responsibleProfessor: TResponsibleProfessor;
+  subject: TSubject;
+};
+
+export type TGetSchedulesHistoricRequestResponse = {
+  data: TSchedules[];
+  meta: {
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
+  };
+};
+
+export type TGetSchedulesHistoricRequestErrorResponse = {
+  statusCode: number;
+  message: string;
+};
+
+export type TGetSchedulesHistoricRequestParams = {
+  startDate?: Date;
+  endDate?: Date;
+  page?: number;
+  subjectIds?: number[];
+  responsibleIds?: number[];
+  studentName?: string;
+  studentEnrollment?: string;
+};

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,6 +12,7 @@ export enum SidebarItemEnum {
   SCHEDULES = 'schedules',
   MONITOR_REQUESTS = 'monitor-requests',
   LOGOUT = 'logout',
+  SCHEDULES_HISTORIC = 'schedules-historic',
 }
 
 export enum TypeUserEnum {

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -1,5 +1,6 @@
 export const SCREENS = {
   SCHEDULES: '/schedules',
+  SCHEDULES_HISTORIC: '/schedules-historic',
   CODE_VERIFICATION: '/code-verification',
   HOME: '/subjects',
   LOGIN: '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4826,6 +4826,11 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@2.6.9, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Cria tela de histórico de agendamentos

# Setup

- [x] yarn
- [ ] yarn start

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Requisição dos dados

- [ ] Popule o banco utilizado com agendamentos já confirmados
- [ ] Entre na aplicação como coordenador
- [ ] Entre na aba de histórico e verifique se os dados foram carregados corretamente
- [ ] Utilize todos os filtros de acordo com os dados no seu banco e verifique se estão funcionais
- [ ] Clique em um agendamento para ver as informações dele
- [ ] Mude a página e verifique se o comportamento bate com os seus dados
- [ ] Repita os mesmos processos como **professor**
- [ ] Verifique se os horários disponíveis são apenas de materias da qual o professor é responsável
- [ ] Cheque se a tela e seus componentes são fieis ao Figma
