### PR TITLE
fix: Filtra agendamentos realizados na tela de histórico

### DIFF
--- a/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
+++ b/src/screens/schedulesHistoric/hooks/useFiltersForm.ts
@@ -5,7 +5,7 @@ import useGetAllProfessors from '../../../service/requests/useGetAllProfessors';
 import useGetProfessorSubjects from '../../../service/requests/useGetProfessorSubjects';
 import { TGetSchedulesHistoricRequestParams } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
 import useGetLoggedUser from '../../../service/storage/getLoggedUser';
-import { TypeUserEnum } from '../../../utils/constants';
+import { SchedulesStatus, TypeUserEnum } from '../../../utils/constants';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import { TScheduleHistoricFilters } from './types';
 
@@ -118,6 +118,7 @@ const useSchedulesHistoric = ({ getSchedules, setPage }: Props) => {
       startDate: filters.beginDateFilter?.toDate(),
       studentName: getValues.name,
       studentEnrollment: getValues.enrollment.toString(),
+      status: SchedulesStatus.REALIZED,
     } as TGetSchedulesHistoricRequestParams;
 
     const ids = filters.responsiblesOrSubjectsFilter.map((attr) =>

--- a/src/screens/schedulesHistoric/hooks/useSchedulesHistoric.ts
+++ b/src/screens/schedulesHistoric/hooks/useSchedulesHistoric.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import useGetSchedulesHistoricRequest from '../../../service/requests/useGetSchedulesHistoricRequest';
 import { TGetSchedulesHistoricRequestParams } from '../../../service/requests/useGetSchedulesHistoricRequest/types';
 import useGetLoggedUser from '../../../service/storage/getLoggedUser';
-import { TypeUserEnum } from '../../../utils/constants';
+import { SchedulesStatus, TypeUserEnum } from '../../../utils/constants';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import useFiltersForm from './useFiltersForm';
 import useFormatSchedules from './useFormatSchedules';
@@ -57,6 +57,7 @@ const useSchedulesHistoric = () => {
       startDate: filters.beginDateFilter?.toDate(),
       studentName: getValues.name,
       studentEnrollment: getValues.enrollment.toString(),
+      status: SchedulesStatus.REALIZED,
     } as TGetSchedulesHistoricRequestParams;
 
     const ids = filters.responsiblesOrSubjectsFilter.map((attr) =>
@@ -75,7 +76,7 @@ const useSchedulesHistoric = () => {
   useEffect(() => {
     document.title = 'Histórico de Agendamentos';
 
-    void getSchedules({ page });
+    void getSchedules({ page, status: SchedulesStatus.REALIZED });
   }, []);
 
   useEffect(() => {

--- a/src/service/requests/useGetSchedulesHistoricRequest/index.tsx
+++ b/src/service/requests/useGetSchedulesHistoricRequest/index.tsx
@@ -1,7 +1,6 @@
 import { AxiosError } from 'axios';
 import moment from 'moment';
 import { useState } from 'react';
-import { SchedulesStatus } from '../../../utils/constants';
 import api from '../../api';
 import {
   TGetSchedulesHistoricErrorResponse,
@@ -19,6 +18,7 @@ const useGetSchedulesHistoricRequest = () => {
     startDate,
     endDate,
     responsibleIds,
+    status,
     studentEnrollment,
     studentName,
     subjectIds,
@@ -37,9 +37,8 @@ const useGetSchedulesHistoricRequest = () => {
 
     try {
       const response = await api.get(
-        `/schedules?pageSize=10&page=${page || 1}&status=${
-          SchedulesStatus.CONFIRMED
-        }${
+        `/schedules?pageSize=10&page=${page || 1}
+        ${status ? `&status=${status}` : ''}${
           startDate
             ? `&startDate=` + moment(startDate).format('YYYY-MM-DD')
             : ``

--- a/src/service/requests/useGetSchedulesHistoricRequest/types.ts
+++ b/src/service/requests/useGetSchedulesHistoricRequest/types.ts
@@ -1,3 +1,5 @@
+import { SchedulesStatus } from '../../../utils/constants';
+
 export type TCourse = {
   id: number;
   name: string;
@@ -70,4 +72,5 @@ export type TGetSchedulesHistoricRequestParams = {
   responsibleIds?: number[];
   studentName?: string;
   studentEnrollment?: string;
+  status?: SchedulesStatus;
 };


### PR DESCRIPTION
# Descrição

- Refatora hook de requisição para listar agendamentos para que ele receba todos os filtros como parâmetros.
  - Antes ele estava atribuindo o filtro de confirmado sempre, sendo que esse filtro deveria ser responsabilidade de quem chama o hook, para que ele seja o mais genérico possível, o que maximiza sua reutilização.
- Na tela de histórico mostra apenas no agendamentos com status `REALIZED`, não `CONFIRMED`.

# Em casos de bugfix

- Qual foi a causa do bug?
  - A tela de histórico estava filtrando agendamentos com status confirmado, sendo que deveria filtrar pelo realizados.
- O que foi feito para corrigi-lo?
  - Muda o status do filtro para REALIZED.

# Setup

- [ ] Atribuia o seguinte valor à ENV: `REACT_APP_API_BASE_URL="https://44.202.14.127:8080/"`
- [ ] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Filtro como coordenador

- [ ] Faça login com a conta `coordenador@icomp.ufam.edu.br` | `12345678`.
- [ ] Clique no botão de Histórico no menu sidebar.
- [ ] Verifique que estão sendo mostrados agendamentos do professor Juan Colonna.

## 2. Filtro como professor responsável

- [ ] Faça login com a conta `juan.professor@icomp.ufam.edu.br` | `12345678`.
- [ ] Clique no botão de Histórico no menu sidebar.
- [ ] Verifique que estão sendo mostrados agendamentos.

## 3. Filtro como professor não responsável

- [ ] Faça login com a conta `tayana.professor@icomp.ufam.edu.br` | `12345678`.
- [ ] Clique no botão de Histórico no menu sidebar.
- [ ] Verifique que não estão sendo mostrados agendamentos.
