### PR TITLE
fix schedule ending

### DIFF
--- a/src/components/ScheduleConfirmationModal/hooks/types.ts
+++ b/src/components/ScheduleConfirmationModal/hooks/types.ts
@@ -1,0 +1,14 @@
+import { TScheduleEnding } from '../../../service/requests/useGetSchedulesEndingRequest/types';
+
+export type TScheduleConfirmationHook = {
+  isOpen: boolean;
+  scheduleState?: TScheduleEnding[];
+  isSuccessUpdate: boolean;
+  isLoadingUpdate: boolean;
+  errorUpdate?: string;
+  numberScheduleOpens: number;
+  selectedSchedule?: TScheduleEnding;
+  handleClickDone(schedule: TScheduleEnding): void;
+  handleClickNotDone(schedule: TScheduleEnding): void;
+  handleCloseModal(): void;
+};

--- a/src/components/ScheduleConfirmationModal/hooks/useScheduleConfirmation.ts
+++ b/src/components/ScheduleConfirmationModal/hooks/useScheduleConfirmation.ts
@@ -5,8 +5,9 @@ import useUpdateScheduleEndingRequest from '../../../service/requests/useUpdateS
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import useScheduleEndingFormat from './useScheduleEndingFormat';
 import { SchedulesStatus } from '../../../utils/constants';
+import { TScheduleConfirmationHook } from './types';
 
-const useScheduleConfirmation = () => {
+const useScheduleConfirmation = (): TScheduleConfirmationHook => {
   const [isOpen, setIsOpen] = useState(false);
   const { showErrorSnackBar, showSuccessSnackBar, showInfoSnackBar } =
     useSnackBar();

--- a/src/components/ScheduleConfirmationModal/hooks/useScheduleConfirmation.ts
+++ b/src/components/ScheduleConfirmationModal/hooks/useScheduleConfirmation.ts
@@ -32,12 +32,12 @@ const useScheduleConfirmation = () => {
   const handleClickDone = (schedule: TScheduleEnding) => {
     setRealized(true);
     setSelectedSchedule(schedule);
-    updateScheduleEnding(schedule.id, realized);
+    updateScheduleEnding(schedule.id, true);
   };
 
   const handleClickNotDone = (schedule: TScheduleEnding) => {
     setSelectedSchedule(schedule);
-    updateScheduleEnding(schedule.id, realized);
+    updateScheduleEnding(schedule.id, false);
   };
 
   const handleCloseModal = () => {

--- a/src/components/ScheduleConfirmationModal/index.tsx
+++ b/src/components/ScheduleConfirmationModal/index.tsx
@@ -7,34 +7,22 @@ import {
   FinalButton,
   SchedulesOpen,
 } from './styles';
-import { TScheduleEnding } from '../../service/requests/useGetSchedulesEndingRequest/types';
 import ScheduleElement from './components/scheduleElement';
+import useScheduleConfirmation from './hooks/useScheduleConfirmation';
 
-type Props = {
-  isOpen: boolean;
-  scheduleState?: TScheduleEnding[];
-  isSuccess: boolean;
-  isLoadingUpdate: boolean;
-  errorUpdate?: string;
-  numberScheduleOpens: number;
-  selectedSchedule?: TScheduleEnding;
-  handleClickDone(schedule: TScheduleEnding): void;
-  handleClickNotDone(schedule: TScheduleEnding): void;
-  handleClose(): void;
-};
-
-const ScheduleConfirmationModal = ({
-  isOpen,
-  scheduleState,
-  handleClose,
-  handleClickDone,
-  handleClickNotDone,
-  isLoadingUpdate,
-  numberScheduleOpens,
-  selectedSchedule,
-}: Props) => {
+const ScheduleConfirmationModal = () => {
+  const {
+    isOpen,
+    scheduleState,
+    isLoadingUpdate,
+    numberScheduleOpens,
+    selectedSchedule,
+    handleClickDone,
+    handleClickNotDone,
+    handleCloseModal,
+  } = useScheduleConfirmation();
   return (
-    <Modal width="991px" isOpen={isOpen} handleClose={handleClose}>
+    <Modal width="991px" isOpen={isOpen} handleClose={handleCloseModal}>
       <Card>
         <HeaderTypography>Confirme sua monitoria</HeaderTypography>
         <SubTypography>
@@ -54,7 +42,10 @@ const ScheduleConfirmationModal = ({
           ))}
         </SchedulesOpen>
         <ButtonContainer>
-          <FinalButton disabled={!!numberScheduleOpens} onClick={handleClose}>
+          <FinalButton
+            disabled={!!numberScheduleOpens}
+            onClick={handleCloseModal}
+          >
             Finalizar Confirmações
           </FinalButton>
         </ButtonContainer>

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -2,11 +2,10 @@ import { Typography } from '@mui/material';
 import AssignProfessorsModal from '../../components/assignProfessorsModal';
 import useAssignProfessorsModal from '../../components/assignProfessorsModal/hooks/useAssignProfessorsModal';
 import ContainerWithSidebar from '../../components/containerWithSidebar';
-import useScheduleConfirmation from '../../components/ScheduleConfirmationModal/hooks/useScheduleConfirmation';
 import ScheduleHelpModal from '../../components/ScheduleHelpModal';
 import useScheduleHelpModal from '../../components/ScheduleHelpModal/hooks/useScheduleHelpModal';
 import SearchField from '../../components/searchField';
-import { SidebarItemEnum } from '../../utils/constants';
+import { SidebarItemEnum, TypeUserEnum } from '../../utils/constants';
 import SubjectsList from './components/SubjectsList';
 import useSubjects from './hooks/useSubjects';
 import { Card, Container } from './styles';
@@ -63,19 +62,6 @@ const Subjects = () => {
     handleShowConfirmation,
   } = useScheduleHelpModal();
 
-  const {
-    isOpen: isOpenScheduleConfirmationModal,
-    scheduleState,
-    isSuccessUpdate: isSuccessUpdate,
-    isLoadingUpdate: isLoadingUpdate,
-    errorUpdate: errorUpdate,
-    numberScheduleOpens: numberScheduleOpens,
-    selectedSchedule: selectedSchedule,
-    handleCloseModal: handleCloseScheduleConfirmation,
-    handleClickDone: handleClickDone,
-    handleClickNotDone: handleClickNotDone,
-  } = useScheduleConfirmation();
-
   return (
     <ContainerWithSidebar selectedSidebarItem={SidebarItemEnum.SUBJECTS}>
       <AssignProfessorsModal
@@ -113,18 +99,12 @@ const Subjects = () => {
         handleConfirmSchedule={handleConfirmSchedule}
       />
 
-      <ScheduleConfirmationModal
-        isOpen={isOpenScheduleConfirmationModal}
-        scheduleState={scheduleState}
-        handleClose={handleCloseScheduleConfirmation}
-        handleClickDone={handleClickDone}
-        handleClickNotDone={handleClickNotDone}
-        isSuccess={isSuccessUpdate}
-        isLoadingUpdate={isLoadingUpdate}
-        errorUpdate={errorUpdate}
-        numberScheduleOpens={numberScheduleOpens}
-        selectedSchedule={selectedSchedule}
-      />
+      {userTypeId === TypeUserEnum.STUDENT ? (
+        <ScheduleConfirmationModal />
+      ) : (
+        <></>
+      )}
+
       <Container>
         <Card>
           <Typography variant="h3">Disciplinas</Typography>


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Corrige erro do parâmetro passado para a request `schedule/id/end`
   - Antes era utilizado o state `realized` para o parametro da request.
- Corrige o erro da requisição `schedule/ending` ser chamada na tela de um usuário que não possui permissão para fazer.

# Em casos de bugfix

- Qual foi a causa do bug?
  - O state `realized` antes usado não era atualizado a tempo da request ser chamada.
- O que foi feito para corrigi-lo?
  - Foi retirado o state `realized` do parametro da request em `handleClickDone`  e `handleClickNotDone` e substitui pelos boolean `true` e `false`

# Setup

- [x] Popular o banco com agendamentos confirmados
- [x] Rodar backend local
- [x] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Erro no request 

- [x] Fazer login como um estudante que possua agendamentos confirmados,
- [x] Clicar no botão `Realizada` 
- [x] Verificar no banco se o agendamento está com `id_status = 4`

## 2. Coordenador usuário não autorizado

- [x] Fazer login como coordenador
- [x] Verificar se a request `schedule/ending` está sendo feito 
