### PR TITLE
fix: Corrige a cor do botão vermelho desabilitado

### DIFF
--- a/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
+++ b/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
@@ -51,9 +51,16 @@ const ScheduleElement = ({
               <>
                 <NegationButton
                   disabled={isLoadingUpdate}
+                  variant="contained"
                   onClick={() => handleClickNotDone(schedule)}
+                  sx={{
+                    '&.Mui-disabled': {
+                      background: '#DC333366',
+                      color: '#fff',
+                    },
+                  }}
                 >
-                  Não realizada
+                  Não Realizada
                 </NegationButton>
                 <ConfirmationButton
                   disabled={isLoadingUpdate}

--- a/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
+++ b/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
@@ -52,12 +52,6 @@ const ScheduleElement = ({
                 <NegationButton
                   disabled={isLoadingUpdate}
                   onClick={() => handleClickNotDone(schedule)}
-                  sx={{
-                    '&.Mui-disabled': {
-                      background: '#DC333366',
-                      color: '#fff',
-                    },
-                  }}
                 >
                   Não realizada
                 </NegationButton>

--- a/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
+++ b/src/components/ScheduleConfirmationModal/components/scheduleElement.tsx
@@ -51,7 +51,6 @@ const ScheduleElement = ({
               <>
                 <NegationButton
                   disabled={isLoadingUpdate}
-                  variant="contained"
                   onClick={() => handleClickNotDone(schedule)}
                   sx={{
                     '&.Mui-disabled': {
@@ -60,7 +59,7 @@ const ScheduleElement = ({
                     },
                   }}
                 >
-                  Não Realizada
+                  Não realizada
                 </NegationButton>
                 <ConfirmationButton
                   disabled={isLoadingUpdate}

--- a/src/components/ScheduleConfirmationModal/styles.ts
+++ b/src/components/ScheduleConfirmationModal/styles.ts
@@ -129,6 +129,10 @@ export const NegationButton = styled(Button).attrs({
 
   width: '50%',
 })`
+  &:disabled {
+    background-color: ${theme.palette.error.main}66 !important;
+  }
+
   @media (max-width: ${theme.breakpoints.values.md}px) {
     width: 50% !important ;
   }


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Altera a cor do botão de agendamento não realizado quando está desabilitado.

# Em casos de bugfix

# Setup

- [ ] `yarn start`
- [ ] Fazer login com conta de aluno foi agendamento para confirmar

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Quando o modal de confirmação abrir, clique no botão `Realizada` ou `Não Realizada`
- [ ] Verificar se os outros botões serão desabilitados e o de `Não Realizada` estará com coloração vermelha 

