### PR TITLE
fix Monitor Request Pagination

### DIFF
--- a/src/screens/monitorRequests/hooks/useMonitorRequests.ts
+++ b/src/screens/monitorRequests/hooks/useMonitorRequests.ts
@@ -4,6 +4,7 @@ import useGetAllMonitorRequests from '../../../service/requests/useGetAllMonitor
 import useGetLoggedUser from '../../../service/storage/getLoggedUser';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import { SCREENS } from '../../../utils/screens';
+import { TypeMonitorStatus } from '../../../utils/constants';
 
 const useMonitorRequests = () => {
   const navigate = useNavigate();
@@ -21,7 +22,7 @@ const useMonitorRequests = () => {
   const [page, setPage] = useState(1);
 
   const totalPages = useMemo(
-    () => requestsResponse?.meta.total_pages || 0,
+    () => requestsResponse?.meta.totalPages || 0,
     [requestsResponse]
   );
   const requests = useMemo(
@@ -32,7 +33,12 @@ const useMonitorRequests = () => {
   const handleSearch = (e: React.SyntheticEvent<EventTarget>) => {
     e.preventDefault();
 
-    void listRequests({ page: 1, search: searchFieldElement.current?.value });
+    void listRequests({
+      page: 1,
+      name: searchFieldElement.current?.value,
+      status: TypeMonitorStatus.PENDING,
+      pageSize: 9,
+    });
     setPage(1);
   };
 
@@ -44,9 +50,11 @@ const useMonitorRequests = () => {
 
     void listRequests({
       page: newPage,
-      search: searchFieldElement.current?.value
+      name: searchFieldElement.current?.value
         ? searchFieldElement.current?.value
         : undefined,
+      status: TypeMonitorStatus.PENDING,
+      pageSize: 9,
     });
     setPage(newPage);
   };
@@ -54,7 +62,7 @@ const useMonitorRequests = () => {
   useEffect(() => {
     if (!user) return navigate(SCREENS.LOGIN);
 
-    void listRequests();
+    void listRequests({ status: TypeMonitorStatus.PENDING, pageSize: 9 });
   }, []);
 
   useEffect(() => {

--- a/src/service/requests/useGetAllMonitorRequests/index.tsx
+++ b/src/service/requests/useGetAllMonitorRequests/index.tsx
@@ -1,6 +1,5 @@
 import { AxiosError } from 'axios';
 import { useState } from 'react';
-import { TypeMonitoringStatus } from '../../../utils/constants';
 import api from '../../api';
 import {
   TListMonitorsRequestsErrorResponse,

--- a/src/service/requests/useGetAllMonitorRequests/index.tsx
+++ b/src/service/requests/useGetAllMonitorRequests/index.tsx
@@ -23,10 +23,6 @@ const useGetAllMonitorRequests = () => {
 
       const dt = response.data as TListMonitorsRequestResponse;
 
-      dt.data = dt.data.filter(
-        (monitor) => monitor.status.status === TypeMonitoringStatus.PENDING
-      );
-
       setData(dt);
     } catch (error) {
       const err = error as AxiosError;

--- a/src/service/requests/useGetAllMonitorRequests/types.ts
+++ b/src/service/requests/useGetAllMonitorRequests/types.ts
@@ -41,21 +41,19 @@ export type TMonitorRequest = {
 
 export type TListMonitorsRequestResponse = {
   meta: {
-    current_page: number;
-    items_per_page: number;
-    total_pages: number;
-    total_items: number;
+    page: number;
+    pageSize: number;
+    totalItems: number;
+    totalPages: number;
   };
   data: TMonitorRequest[];
 };
 
 export type TListMonitorsRequestParams = {
-  quantity?: number;
-  number?: number;
   page?: number;
-  field?: string;
-  order?: 'asc' | 'desc';
-  search?: string;
+  pageSize?: number;
+  name?: string;
+  status?: number;
 };
 
 export type TListMonitorsRequestsErrorResponse = {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -43,6 +43,14 @@ export enum SchedulesStatus {
   NOT_REALIZED = 5,
 }
 
+export enum TypeMonitorStatus {
+  PENDING = 1,
+  APPROVED = 2,
+  AVAILABLE = 3,
+  FINISHED = 4,
+  REJECTED = 5,
+}
+
 export const ScheduleStatusTranslate = {
   [SchedulesStatus.PENDING]: 'Pendente',
   [SchedulesStatus.CONFIRMED]: 'Confirmado',


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Adequa os hooks `useMonitorRequest` e `useGetAllMonitorRequests` para funcionar de acordo com a alteração na rota `GET /monitor/all`

# Em casos de bugfix

- Qual foi a causa do bug?
 - A filtragem dos monitores pendentes era feito diretamente no front da tela, o que estava resultado em um erro com a paginação dos dados vindos do banco.
- O que foi feito para corrigi-lo?
 - Alteração na rota `GET /monitor/all` para filtrar um tipo de status específico passado como parâmetro na requisição;
 - Modificação dos hooks `useMonitorRequest` e `useGetAllMonitorRequests` para funcionar com as alterações da rota;

# Setup

- [ ] `yarn start`
- [ ] Garantir que uma conta de professor possua mais de 10 solicitações de monitor pendente

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Fazer Login com uma conta de professor com mais de 10 solicitações de monitor pendente
- [ ] Abra a tela de solicitação
- [ ] Verifique se a paginação está com problema e se estão sendo exibidos as solicitações da forma que deveria