### PR TITLE
Fix: Aplica ícone de senha nos cadastros

### DIFF
--- a/src/screens/registerProfessor/components/FormRegister/index.tsx
+++ b/src/screens/registerProfessor/components/FormRegister/index.tsx
@@ -47,6 +47,8 @@ const FormRegister = () => {
     setPasswordError,
     confPassword,
     confPasswordError,
+    showConfirmPassword,
+    handleClickShowConfirmPassword,
     handleConfPasswordChange,
     setConfPasswordError,
     isLoading,
@@ -134,12 +136,24 @@ const FormRegister = () => {
                     name="password"
                     onChange={handlePasswordChange}
                     placeholder="Crie sua senha*"
+                    endAdornment={
+                      <InputAdornment position="end">
+                        <IconButton
+                          aria-label="toggle password visibility"
+                          onClick={handleClickShowPassword}
+                          onMouseDown={handleMouseDownPassword}
+                          edge="end"
+                        >
+                          {showPassword ? <VisibilityOff /> : <Visibility />}
+                        </IconButton>
+                      </InputAdornment>
+                    }
                   />
                   <PasswordError />
                 </TextFieldContainer>
                 <TextFieldContainer>
                   <StyledFormTextField
-                    type={showPassword ? 'text' : 'password'}
+                    type={showConfirmPassword ? 'text' : 'password'}
                     onBlur={() =>
                       setConfPasswordError(
                         validateConfirmPassword(password, confPassword)
@@ -155,11 +169,15 @@ const FormRegister = () => {
                       <InputAdornment position="end">
                         <IconButton
                           aria-label="toggle password visibility"
-                          onClick={handleClickShowPassword}
+                          onClick={handleClickShowConfirmPassword}
                           onMouseDown={handleMouseDownPassword}
                           edge="end"
                         >
-                          {showPassword ? <VisibilityOff /> : <Visibility />}
+                          {showConfirmPassword ? (
+                            <VisibilityOff />
+                          ) : (
+                            <Visibility />
+                          )}
                         </IconButton>
                       </InputAdornment>
                     }

--- a/src/screens/registerProfessor/components/hooks/types.ts
+++ b/src/screens/registerProfessor/components/hooks/types.ts
@@ -19,6 +19,8 @@ export type TRegisterProfessorHook = {
 
   confPassword: string;
   confPasswordError: string;
+  showConfirmPassword: boolean;
+  handleClickShowConfirmPassword(): void;
   handleConfPasswordChange(e: React.ChangeEvent<HTMLInputElement>): void;
   setConfPasswordError(confPassword: string): void;
 

--- a/src/screens/registerProfessor/components/hooks/useRegisterProfessor.ts
+++ b/src/screens/registerProfessor/components/hooks/useRegisterProfessor.ts
@@ -26,6 +26,7 @@ const useRegisterProfessor = () => {
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
@@ -46,6 +47,10 @@ const useRegisterProfessor = () => {
 
   const handleClickShowPassword = () => {
     setShowPassword(!showPassword);
+  };
+
+  const handleClickShowConfirmPassword = () => {
+    setShowConfirmPassword(!showConfirmPassword);
   };
 
   const handleMouseDownPassword = (
@@ -123,6 +128,7 @@ const useRegisterProfessor = () => {
     handleCancelClick,
     handleContinueClick,
     handleClickShowPassword,
+    handleClickShowConfirmPassword,
     handleMouseDownPassword,
     name,
     email,
@@ -136,6 +142,7 @@ const useRegisterProfessor = () => {
     passwordError,
     confPasswordError,
     showPassword,
+    showConfirmPassword,
     setNameError,
     setEmailError,
     setPasswordError,

--- a/src/screens/registerStudent/components/StartStudentRegister/index.tsx
+++ b/src/screens/registerStudent/components/StartStudentRegister/index.tsx
@@ -21,10 +21,12 @@ import {
 const StartStudentRegister = ({
   confirmPassword,
   confirmPasswordError,
+  showConfirmPassword,
   email,
   emailError,
   handleCancelRegisterClick,
   handleClickShowPassword,
+  handleClickShowConfirmPassword,
   handleConfirmPasswordChange,
   handleContinueClick,
   handleEmailChange,
@@ -111,12 +113,24 @@ const StartStudentRegister = ({
             name="password"
             placeholder="Crie sua senha*"
             onChange={handlePasswordChange}
+            endAdornment={
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={handleClickShowPassword}
+                  onMouseDown={handleMouseDownPassword}
+                  edge="end"
+                >
+                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                </IconButton>
+              </InputAdornment>
+            }
           />
           <PasswordError />
         </StyledFormBox>
         <StyledFormBox>
           <StyledFormTextField
-            type={showPassword ? 'text' : 'password'}
+            type={showConfirmPassword ? 'text' : 'password'}
             onBlur={() =>
               setConfirmPasswordError(
                 validateConfirmPassword(password, confirmPassword)
@@ -132,11 +146,11 @@ const StartStudentRegister = ({
               <InputAdornment position="end">
                 <IconButton
                   aria-label="toggle password visibility"
-                  onClick={handleClickShowPassword}
+                  onClick={handleClickShowConfirmPassword}
                   onMouseDown={handleMouseDownPassword}
                   edge="end"
                 >
-                  {showPassword ? <VisibilityOff /> : <Visibility />}
+                  {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
                 </IconButton>
               </InputAdornment>
             }

--- a/src/screens/registerStudent/hooks/types.ts
+++ b/src/screens/registerStudent/hooks/types.ts
@@ -20,6 +20,8 @@ export type TStartStudentRegisterHook = {
 
   confirmPassword: string;
   confirmPasswordError: string;
+  showConfirmPassword: boolean;
+  handleClickShowConfirmPassword(): void;
   handleConfirmPasswordChange(e: React.ChangeEvent<HTMLInputElement>): void;
   setConfirmPasswordError(confirmPassword: string): void;
 

--- a/src/screens/registerStudent/hooks/useRegister.ts
+++ b/src/screens/registerStudent/hooks/useRegister.ts
@@ -43,6 +43,7 @@ const useRegister = () => {
   const [whatsappError, setWhatsappError] = useState('');
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [nameError, setNameError] = useState('');
   const [enrollmentError, setEnrollmentError] = useState('');
@@ -120,6 +121,10 @@ const useRegister = () => {
 
   const handleClickShowPassword = () => {
     setShowPassword(!showPassword);
+  };
+
+  const handleClickShowConfirmPassword = () => {
+    setShowConfirmPassword(!showConfirmPassword);
   };
 
   const handleMouseDownPassword = (
@@ -258,12 +263,14 @@ const useRegister = () => {
     email,
     password,
     confirmPassword,
+    showConfirmPassword,
     showPassword,
     handleNameChange,
     handleConfirmPasswordChange,
     handleEmailChange,
     handlePasswordChange,
     handleClickShowPassword,
+    handleClickShowConfirmPassword,
     handleMouseDownPassword,
     handleContinueClick,
     nameError,

--- a/src/screens/registerStudent/index.tsx
+++ b/src/screens/registerStudent/index.tsx
@@ -20,6 +20,7 @@ const RegisterStudent = () => {
   const {
     confirmPassword,
     confirmPasswordError,
+    showConfirmPassword,
     contactEmail,
     course,
     courseError,
@@ -32,6 +33,7 @@ const RegisterStudent = () => {
     handleBackClick,
     handleCancelRegisterClick,
     handleClickShowPassword,
+    handleClickShowConfirmPassword,
     handleConfirmPasswordChange,
     handleContactEmailChange,
     handleContinueClick,
@@ -98,8 +100,10 @@ const RegisterStudent = () => {
             handlePasswordChange={handlePasswordChange}
             confirmPassword={confirmPassword}
             confirmPasswordError={confirmPasswordError}
+            showConfirmPassword={showConfirmPassword}
             handleConfirmPasswordChange={handleConfirmPasswordChange}
             handleClickShowPassword={handleClickShowPassword}
+            handleClickShowConfirmPassword={handleClickShowConfirmPassword}
             handleMouseDownPassword={handleMouseDownPassword}
             handleContinueClick={handleContinueClick}
             handleCancelRegisterClick={handleCancelRegisterClick}

--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -47,10 +47,10 @@ const ConfirmedScheduleModalContent = ({
 
     <ButtonsContainer>
       <ActionButton variant="text" color="primary" onClick={handleClose}>
-        Fechar
+        Desmarcar
       </ActionButton>
       <ActionButton color="primary" onClick={handleOpenCancelModal}>
-        Desmarcar
+        Fechar
       </ActionButton>
     </ButtonsContainer>
   </>

--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -46,10 +46,14 @@ const ConfirmedScheduleModalContent = ({
     </DataContainer>
 
     <ButtonsContainer>
-      <ActionButton variant="text" color="primary" onClick={handleClose}>
+      <ActionButton
+        variant="text"
+        color="primary"
+        onClick={handleOpenCancelModal}
+      >
         Desmarcar
       </ActionButton>
-      <ActionButton color="primary" onClick={handleOpenCancelModal}>
+      <ActionButton color="primary" onClick={handleClose}>
         Fechar
       </ActionButton>
     </ButtonsContainer>


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Aplica ícone de visualização de senha nos  campos de senha e confirmação de senha nas telas de cadastro de aluno e de professor.

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acessar tela de cadastro de professor
- [ ] Visualizar se o campo de senha e confirmação de senha estão com os ícones de visualização da senha
- [ ] Verificar se ambos os botões estão funcionando de forma correta

## 2. Cenário B**

- [ ] Acessar tela de cadastro de aluno
- [ ] Visualizar se o campo de senha e confirmação de senha estão com os ícones de visualização da senha
- [ ] Verificar se ambos os botões estão funcionando de forma correta
