### PR TITLE
Fix remove 48h

### DIFF
--- a/src/components/ScheduleHelpModal/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/ConfirmedScheduleModalContent/index.tsx
@@ -11,10 +11,6 @@ const ConfirmedScheduleModalContent = ({ handleClose }: Props) => (
     <CheckedAnimation />
 
     <Typography variant="h4">Muito bem!</Typography>
-    <Typography variant="body1" textAlign={'center'}>
-      Foi enviado ao monitor uma solicitação de agendamento, em até 48hrs você
-      receberá a resposta.
-    </Typography>
 
     <StyledButton sx={{ margin: '16px 0 8px 0' }} onClick={handleClose}>
       Voltar

--- a/src/components/ScheduleHelpModal/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/ConfirmedScheduleModalContent/index.tsx
@@ -11,7 +11,9 @@ const ConfirmedScheduleModalContent = ({ handleClose }: Props) => (
     <CheckedAnimation />
 
     <Typography variant="h4">Muito bem!</Typography>
-
+    <Typography variant="body1" textAlign={'center'}>
+      Foi enviado ao monitor uma solicitação de agendamento.
+    </Typography>
     <StyledButton sx={{ margin: '16px 0 8px 0' }} onClick={handleClose}>
       Voltar
     </StyledButton>

--- a/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
+++ b/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
@@ -149,12 +149,6 @@ const useScheduleHelpModal = () => {
     resetScheduleStates();
   }, [scheduleError]);
 
-  useEffect(() => {
-    if (!isScheduleSuccess) return;
-
-    showSuccessSnackBar(`Monitoria agendada com sucesso!`);
-  }, [isScheduleSuccess]);
-
   return {
     availableHours,
     availableMonitors,


### PR DESCRIPTION
# Descrição

- Remove o aviso de 48h no agendamento de monitoria e a snackbar 

# Setup

- [ ] `yarn build`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Efetuar Login como aluno
- [ ] Agendar uma monitoria
- [ ] Verificar se após o agendamento a mensagem de sucesso possui "em até 48hrs você
      receberá a resposta."
- [ ] Verificar se a snackbar aparece depois do sucesso.