### PR TITLE
fix: Diminui assets da LP para não sobrepor textos

### DIFF
--- a/src/screens/landingPage/components/advantages/styles.ts
+++ b/src/screens/landingPage/components/advantages/styles.ts
@@ -152,14 +152,10 @@ export const TopLeftImage = styled(Box)`
   background-size: contain;
   background-repeat: no-repeat;
   background-image: url(${TopLeftImage1920});
-  margin-top: -228px;
-  width: 298px;
-  height: 388px;
-  @media (max-width: ${theme.breakpoints.values.md}px) {
-    margin-top: -120px !important;
-    width: 158px !important;
-    height: 206px !important;
-  }
+
+  margin-top: -120px !important;
+  width: 158px !important;
+  height: 206px !important;
   @media (max-width: ${theme.breakpoints.values.sm}px) {
     margin-top: -80px !important;
     width: 106px !important;
@@ -173,15 +169,11 @@ export const TopRightImage = styled(Box)`
   right: 0;
   background-size: contain;
   background-repeat: no-repeat;
-  margin-top: -228px;
   background-image: url(${TopRightImage1920});
-  width: 310px;
-  height: 388px;
-  @media (max-width: ${theme.breakpoints.values.md}px) {
-    margin-top: -120px !important;
-    width: 164px !important;
-    height: 206px !important;
-  }
+  margin-top: -120px !important;
+  width: 164px !important;
+  height: 206px !important;
+
   @media (max-width: ${theme.breakpoints.values.sm}px) {
     margin-top: -80px !important;
     width: 111px !important;
@@ -195,15 +187,11 @@ export const BottomLeftImage = styled(Box)`
   left: 0;
   background-size: contain;
   background-repeat: no-repeat;
-  margin-bottom: -156px;
   background-image: url(${BottomLeftImage1920});
-  width: 204px;
-  height: 288px;
-  @media (max-width: ${theme.breakpoints.values.md}px) {
-    width: 108px !important;
-    height: 152px !important;
-    margin-bottom: -82px;
-  }
+  width: 108px !important;
+  height: 152px !important;
+  margin-bottom: -82px;
+
   @media (max-width: ${theme.breakpoints.values.sm}px) {
     width: 72px !important;
     margin-bottom: -56px;
@@ -217,15 +205,11 @@ export const BottomRightImage = styled(Box)`
   right: 0;
   background-size: contain;
   background-repeat: no-repeat;
-  margin-bottom: -156px;
   background-image: url(${BottomRightImage1920});
-  width: 298px;
-  height: 288px;
-  @media (max-width: ${theme.breakpoints.values.md}px) {
-    width: 158px !important;
-    margin-bottom: -82px;
-    height: 152px !important;
-  }
+  width: 158px !important;
+  margin-bottom: -82px;
+  height: 152px !important;
+
   @media (max-width: ${theme.breakpoints.values.sm}px) {
     width: 105px !important;
     margin-bottom: -56px;


### PR DESCRIPTION
# Descrição

Diminui tamanho dos assets laterais da landing page para que não corramos o risco deles ficarem muito grandes em alguns monitores e ficarem por cima de algum texto ou componente.

# Setup

- [ ] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Landing page com 764px de altura

- [ ] Abra o link http://localhost:3000/about e ajuste a altura da tela para ter 764px de altura e mais de 1300px de largura.
- [ ] Verifique que os assets não sobrepões nenhuma parte da tela:


Antes  | Depois
--------- | ------
<img width="1440" alt="Captura de Tela 2023-04-22 às 16 54 48" src="https://user-images.githubusercontent.com/26875510/233806260-1388dafb-93ad-4e43-a24a-fcbd34a0dffe.png"> | <img width="1440" alt="Captura de Tela 2023-04-22 às 16 55 34" src="https://user-images.githubusercontent.com/26875510/233806337-cca4268f-49d9-4b2d-bfbe-50c5dd3535e0.png">
