### PR TITLE
fix: Adiciona 4 horas ao agendamento

### DIFF
--- a/src/screens/schedules/hooks/useFormatSchedules.ts
+++ b/src/screens/schedules/hooks/useFormatSchedules.ts
@@ -6,11 +6,20 @@ import {
 import { TFormatedSchedules } from './types';
 
 const useFormatSchedules = (response?: TGetSchedulesRequestResponse) => {
-  const formatDateType = (schedule: TSchedules) => ({
-    ...schedule,
-    start: new Date(schedule.start),
-    end: new Date(schedule.end),
-  });
+  const formatDateType = (schedule: TSchedules) => {
+    const AMT_OFFSET = -4;
+    const start = new Date(schedule.start);
+    start.setHours(start.getHours() - AMT_OFFSET);
+
+    const end = new Date(schedule.end);
+    end.setHours(end.getHours() - AMT_OFFSET);
+
+    return {
+      ...schedule,
+      start,
+      end,
+    };
+  };
 
   const groupSchedulesByDate = (
     groups: Map<string, TSchedules[]>,

--- a/src/screens/schedulesHistoric/hooks/useFormatSchedules.ts
+++ b/src/screens/schedulesHistoric/hooks/useFormatSchedules.ts
@@ -9,11 +9,20 @@ import { TFormatedSchedules } from './types';
 const useFormatSchedules = (
   response?: TGetSchedulesHistoricRequestResponse
 ) => {
-  const formatDateType = (schedule: TSchedules) => ({
-    ...schedule,
-    startDate: new Date(schedule.startDate),
-    endDate: new Date(schedule.endDate),
-  });
+  const formatDateType = (schedule: TSchedules) => {
+    const AMT_OFFSET = -4;
+    const startDate = new Date(schedule.startDate);
+    startDate.setHours(startDate.getHours() - AMT_OFFSET);
+
+    const endDate = new Date(schedule.endDate);
+    endDate.setHours(endDate.getHours() - AMT_OFFSET);
+
+    return {
+      ...schedule,
+      startDate,
+      endDate,
+    };
+  };
 
   const groupSchedulesByDate = (
     groups: Map<string, TSchedules[]>,


### PR DESCRIPTION
# Descrição

**[[CARD] Horário agendado de monitoria aparece diferente do selecionado](https://computero.atlassian.net/browse/DS-72?atlOrigin=eyJpIjoiMDE1OTJlYzgzMGE2NGU3NzhiMjZkYzI2NDNjOTkwMDMiLCJwIjoiaiJ9)**

Adiciona 4 horas aos agendamentos mostrados na tela de agendamentos e na tela de histórico para que eles sejam mostrados corretamente.

# Em casos de bugfix

- Qual foi a causa do bug?
  - As datas atualmente são salvas no banco no padrão AMT, então quando o front recebe um agendamento mostra a hora tirando 4 horas, porém as 4 horas no AMT já foram descontadas, o que faz a data estar errada.
- O que foi feito para corrigi-lo?
  - Adiciona 4 horas nos agendamentos mostrados nas duas telas, assim quando a função descontar 4 vai ficar com diferença zerada.

# Setup

- [x] Altere o `.env` para apontar ao backend de stg.
- [x] `yarn start`

# Cenários

## 1. Tela de agendamentos

- [x] Faça login com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`.
- [x] Entre na tela da disciplina `Desenvolvimento De Aplicativos Para Dispositivos Móveis`.
- [x] Agende uma monitoria com o monitor Marcos Paulo.
- [x] Entre na tela de agendamentos e verifique se o horário da monitoria que acabou de ser criada é igual ao horário que você informout ao agendar.

## 2. Tela de histórico de agendamentos

- [x] Faça login com a conta `coordenador@icomp.ufam.edu.br` | `12345678`.
- [x] Entre na tela de histórico e faça uma busca por nome por `marcos`.
- [x] Verifique se o agendamento em que o Marcos foi monitor do Nabson no dia 01 de abril está com os horários `10:00 até 11:00`.
