### PR TITLE
feat: Add campo de descrição no agendamento

### DIFF
--- a/src/components/ScheduleHelpModal/components/ConfirmScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/ConfirmScheduleModalContent/index.tsx
@@ -10,6 +10,7 @@ import { DataContainer, Label } from './styles';
 type Props = {
   availableHours: string[];
   availableMonitors: TSubjectMonitor[];
+  description: string;
   selectedDate: moment.Moment | null;
   selectedHourIndex: number;
   selectedProfessorId: number;
@@ -22,6 +23,7 @@ type Props = {
 const ConfirmScheduleModalContent = ({
   availableHours,
   availableMonitors,
+  description,
   selectedDate,
   selectedHourIndex,
   selectedMonitorId,
@@ -71,6 +73,11 @@ const ConfirmScheduleModalContent = ({
         value: availableHours[selectedHourIndex],
       });
     }
+
+    data.push({
+      label: 'Descrição',
+      value: description || '-',
+    });
 
     return data;
   }, [selectedProfessorId, selectedMonitorId, selectedDate, selectedHourIndex]);

--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -1,4 +1,11 @@
-import { MenuItem, Select, SelectChangeEvent, Typography } from '@mui/material';
+import {
+  FormHelperText,
+  MenuItem,
+  Select,
+  SelectChangeEvent,
+  Typography,
+  useMediaQuery,
+} from '@mui/material';
 import { DesktopDatePicker } from '@mui/x-date-pickers';
 import moment from 'moment';
 import { TMonitorAvailableTime } from '../../../../service/requests/useGetMonitorAvailableTimesRequest/types';
@@ -6,13 +13,21 @@ import {
   TCompleteSubject,
   TSubjectMonitor,
 } from '../../../../service/requests/useGetSubject/types';
+import theme from '../../../../utils/theme';
 import { TextField } from '../../../textField';
 import { ButtonsContainer, StyledButton } from '../../styles';
-import { DateFieldsContainer, DateTextField, Placeholder } from './styles';
+import {
+  DateFieldsContainer,
+  DateTextField,
+  DescriptionContainer,
+  DescriptionTextField,
+  Placeholder,
+} from './styles';
 
 type Props = {
   availableHours: string[];
   availableMonitors: TSubjectMonitor[];
+  description: string;
   isLoadingMonitorAvailableTimes: boolean;
   monitorAvailableTimes?: TMonitorAvailableTime[];
   selectedDate: moment.Moment | null;
@@ -22,6 +37,7 @@ type Props = {
   subject: TCompleteSubject;
   handleClose(): void;
   handleChangeDate(value: moment.Moment | null): void;
+  handleChangeDescription(e: React.ChangeEvent<HTMLInputElement>): void;
   handleChangeHour(event: SelectChangeEvent<string[]>): void;
   handleChangeMonitor(event: SelectChangeEvent<string[]>): void;
   handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
@@ -31,6 +47,7 @@ type Props = {
 const FormScheduleModalContent = ({
   availableHours,
   availableMonitors,
+  description,
   isLoadingMonitorAvailableTimes,
   monitorAvailableTimes,
   selectedDate,
@@ -39,117 +56,68 @@ const FormScheduleModalContent = ({
   selectedProfessorId,
   subject,
   handleChangeDate,
+  handleChangeDescription,
   handleChangeHour,
   handleChangeMonitor,
   handleChangeProfessor,
   handleClose,
   handleShowConfirmation,
-}: Props) => (
-  <>
-    <Typography variant="h4">Novo agendamento</Typography>
-    <Typography variant="body1">
-      Complete as informações abaixo para o agendar a monitoria na disciplina{' '}
-      <strong>{subject.name}</strong>
-    </Typography>
+}: Props) => {
+  const shouldExpandDescriptionLines = useMediaQuery(
+    theme.breakpoints.down('sm')
+  );
 
-    <Select
-      disabled={!subject.responsables.length}
-      displayEmpty
-      value={[selectedProfessorId.toFixed()]}
-      onChange={handleChangeProfessor}
-      input={<TextField />}
-      renderValue={(selected: string[]) =>
-        Number(selected) === -1 ? (
-          <Placeholder>Selecionar Professor(a)</Placeholder>
-        ) : (
-          <Typography>
-            {subject.responsables.find(
-              (responsables) =>
-                responsables.professor.user.id === Number(selected[0])
-            )?.professor.user.name || ''}
-          </Typography>
-        )
-      }
-    >
-      {[
-        <MenuItem key={-1} value={-1}>
-          Selecionar Professor(a)
-        </MenuItem>,
-        ...subject.responsables.map((subjectResponsible) => (
-          <MenuItem
-            key={subjectResponsible.professor.user.id}
-            value={subjectResponsible.professor.user.id}
-          >
-            {subjectResponsible.professor.user.name}
-          </MenuItem>
-        )),
-      ]}
-    </Select>
-
-    <Select
-      disabled={selectedProfessorId === -1}
-      displayEmpty
-      value={[selectedMonitorId.toFixed()]}
-      onChange={handleChangeMonitor}
-      input={<TextField />}
-      renderValue={(selected: string[]) =>
-        Number(selected) === -1 ? (
-          <Placeholder>Selecionar Monitor(a)</Placeholder>
-        ) : (
-          <Typography>
-            {availableMonitors.find(
-              (monitor) => monitor.id === Number(selected[0])
-            )?.name || ''}
-          </Typography>
-        )
-      }
-    >
-      {[
-        <MenuItem key={-1} value={-1}>
-          Selecionar Monitor(a)
-        </MenuItem>,
-        ...availableMonitors.map((monitor) => (
-          <MenuItem key={monitor.id} value={monitor.id}>
-            {monitor.name}
-          </MenuItem>
-        )),
-      ]}
-    </Select>
-
-    <DateFieldsContainer>
-      <DesktopDatePicker
-        disabled={selectedMonitorId === -1}
-        disablePast
-        inputFormat="DD/MM/YYYY"
-        value={selectedDate}
-        onChange={handleChangeDate}
-        renderInput={(params) => (
-          <DateTextField
-            {...params}
-            inputProps={{
-              ...params.inputProps,
-              placeholder: 'Selecione a data',
-            }}
-          />
-        )}
-        loading={isLoadingMonitorAvailableTimes}
-        shouldDisableDate={(day) =>
-          !monitorAvailableTimes?.find((time) => time.week_day === day.day())
-        }
-      />
-
+  return (
+    <>
+      <Typography variant="h4">Novo agendamento</Typography>
+      <Typography variant="body1">
+        Complete as informações abaixo para agendar a monitoria na disciplina{' '}
+        <strong>{subject.name}</strong>
+      </Typography>
       <Select
-        sx={{ width: '100%' }}
-        disabled={selectedDate === null}
+        disabled={!subject.responsables.length}
         displayEmpty
-        value={[selectedHourIndex.toFixed()]}
-        onChange={handleChangeHour}
+        value={[selectedProfessorId.toFixed()]}
+        onChange={handleChangeProfessor}
         input={<TextField />}
         renderValue={(selected: string[]) =>
           Number(selected) === -1 ? (
-            <Placeholder>Selecionar horário</Placeholder>
+            <Placeholder>Selecionar Professor(a)</Placeholder>
           ) : (
-            <Typography>{availableHours[selectedHourIndex] || ''}</Typography>
+            <Typography>
+              {subject.responsables.find(
+                (prof) => prof.id === Number(selected[0])
+              )?.professor.user.name || ''}
+            </Typography>
+          )
+        }
+      >
+        {[
+          <MenuItem key={-1} value={-1}>
+            Selecionar Professor(a)
+          </MenuItem>,
+          ...subject.responsables.map((professor) => (
+            <MenuItem key={professor.id} value={professor.id}>
+              {professor.professor.user.name}
+            </MenuItem>
+          )),
+        ]}
+      </Select>
+      <Select
+        disabled={selectedProfessorId === -1}
+        displayEmpty
+        value={[selectedMonitorId.toFixed()]}
+        onChange={handleChangeMonitor}
+        input={<TextField />}
+        renderValue={(selected: string[]) =>
+          Number(selected) === -1 ? (
+            <Placeholder>Selecionar Monitor(a)</Placeholder>
+          ) : (
+            <Typography>
+              {availableMonitors.find(
+                (monitor) => monitor.id === Number(selected[0])
+              )?.name || ''}
+            </Typography>
           )
         }
       >
@@ -157,29 +125,90 @@ const FormScheduleModalContent = ({
           <MenuItem key={-1} value={-1}>
             Selecionar Monitor(a)
           </MenuItem>,
-          ...availableHours.map((hour, index) => (
-            <MenuItem key={index} value={index}>
-              {hour}
+          ...availableMonitors.map((monitor) => (
+            <MenuItem key={monitor.id} value={monitor.id}>
+              {monitor.name}
             </MenuItem>
           )),
         ]}
       </Select>
-    </DateFieldsContainer>
+      <DateFieldsContainer>
+        <DesktopDatePicker
+          disabled={selectedMonitorId === -1}
+          disablePast
+          inputFormat="DD/MM/YYYY"
+          value={selectedDate}
+          onChange={handleChangeDate}
+          renderInput={(params) => (
+            <DateTextField
+              {...params}
+              inputProps={{
+                ...params.inputProps,
+                placeholder: 'Selecione a data',
+              }}
+            />
+          )}
+          loading={isLoadingMonitorAvailableTimes}
+          shouldDisableDate={(day) =>
+            !monitorAvailableTimes?.find((time) => time.week_day === day.day())
+          }
+        />
 
-    <ButtonsContainer>
-      <StyledButton variant="text" onClick={handleClose}>
-        Cancelar
-      </StyledButton>
+        <Select
+          sx={{ width: '100%' }}
+          disabled={selectedDate === null}
+          displayEmpty
+          value={[selectedHourIndex.toFixed()]}
+          onChange={handleChangeHour}
+          input={<TextField />}
+          renderValue={(selected: string[]) =>
+            Number(selected) === -1 ? (
+              <Placeholder>Selecionar horário</Placeholder>
+            ) : (
+              <Typography>{availableHours[selectedHourIndex] || ''}</Typography>
+            )
+          }
+        >
+          {[
+            <MenuItem key={-1} value={-1}>
+              Selecionar Monitor
+            </MenuItem>,
+            ...availableHours.map((hour, index) => (
+              <MenuItem key={index} value={index}>
+                {hour}
+              </MenuItem>
+            )),
+          ]}
+        </Select>
+      </DateFieldsContainer>
 
-      <StyledButton
-        onClick={handleShowConfirmation}
-        disabled={selectedHourIndex === -1}
-        width="230px"
-      >
-        Concluir agendamento
-      </StyledButton>
-    </ButtonsContainer>
-  </>
-);
+      <DescriptionContainer>
+        <DescriptionTextField
+          disabled={selectedHourIndex === -1}
+          value={description}
+          onChange={handleChangeDescription}
+          minRows={shouldExpandDescriptionLines ? 10 : 4}
+        />
+        <FormHelperText sx={{ textAlign: 'right', paddingRight: '10px' }}>
+          {selectedHourIndex !== -1 && `${description.length} / 500`}
+        </FormHelperText>
+      </DescriptionContainer>
+
+      <ButtonsContainer>
+        <StyledButton variant="text" onClick={handleClose}>
+          Cancelar
+        </StyledButton>
+
+        <StyledButton
+          onClick={handleShowConfirmation}
+          disabled={selectedHourIndex === -1}
+          width="230px"
+        >
+          Concluir agendamento
+        </StyledButton>
+      </ButtonsContainer>
+    </>
+  );
+};
 
 export default FormScheduleModalContent;

--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -171,7 +171,7 @@ const FormScheduleModalContent = ({
         >
           {[
             <MenuItem key={-1} value={-1}>
-              Selecionar Monitor
+              Selecionar horário
             </MenuItem>,
             ...availableHours.map((hour, index) => (
               <MenuItem key={index} value={index}>

--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/styles.ts
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/styles.ts
@@ -1,7 +1,8 @@
-import { TextField, Typography } from '@mui/material';
+import { TextField as MUITextField, Typography } from '@mui/material';
 import { Box } from '@mui/system';
 import styled from 'styled-components';
 import theme from '../../../../utils/theme';
+import { TextField } from '../../../textField';
 
 export const DateFieldsContainer = styled(Box).attrs({
   display: 'flex',
@@ -14,7 +15,7 @@ export const DateFieldsContainer = styled(Box).attrs({
   }
 `;
 
-export const DateTextField = styled(TextField).attrs({})`
+export const DateTextField = styled(MUITextField).attrs({})`
   width: 100%;
 
   fieldset {
@@ -35,4 +36,20 @@ export const FeedbackContainer = styled(Box).attrs({
   gap: '16px',
   padding: '0 20px',
   flexDirection: 'column',
+})``;
+
+export const DescriptionTextField = styled(TextField).attrs({
+  type: 'text',
+  name: 'description',
+  multiline: true,
+  placeholder:
+    'Descreva o motivo do agendamento, cite informações como:\n - Quais são suas dúvidas?\n - Você fará sozinho ou em grupo? (Caso seja em grupo, informe quem irá participar.)\n - Você prefere que seja presencial ou online?',
+  inputProps: { maxLength: 500 },
+})``;
+
+export const DescriptionContainer = styled(Box).attrs({
+  display: 'flex',
+  justifyContent: 'center',
+  flexDirection: 'column',
+  width: '100%',
 })``;

--- a/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
+++ b/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
@@ -31,6 +31,7 @@ const useScheduleHelpModal = () => {
   const [selectedMonitorId, setSelectedMonitorId] = useState(-1);
   const [selectedDate, setSelectedDate] = useState<moment.Moment | null>(null);
   const [selectedHourIndex, setSelectedHourIndex] = useState(-1);
+  const [description, setDescription] = useState('');
 
   const availableMonitors = useMemo(() => {
     if (!selectedSubject || selectedProfessorId === -1) return [];
@@ -66,6 +67,7 @@ const useScheduleHelpModal = () => {
     setSelectedDate(null);
     setSelectedMonitorId(-1);
     setSelectedProfessorId(-1);
+    setDescription('');
     setIsOpen(false);
   };
 
@@ -92,7 +94,7 @@ const useScheduleHelpModal = () => {
     const start = `${selectedDate.format('YYYY-MM-DD')} ${hour[0]}`;
     const end = `${selectedDate.format('YYYY-MM-DD')} ${hour[1]}`;
 
-    void schedule(selectedMonitorId, start, end);
+    void schedule(selectedMonitorId, start, end, description);
   };
 
   const handleShowConfirmation = () => setShowConfirmation(true);
@@ -136,6 +138,10 @@ const useScheduleHelpModal = () => {
     setSelectedHourIndex(Number(value));
   };
 
+  const handleChangeDescription = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDescription(e.target.value);
+  };
+
   useEffect(() => {
     if (selectedMonitorId === -1) return;
 
@@ -152,6 +158,7 @@ const useScheduleHelpModal = () => {
   return {
     availableHours,
     availableMonitors,
+    description,
     isLoadingMonitorAvailableTimes,
     isScheduleLoading,
     isScheduleSuccess,
@@ -164,6 +171,7 @@ const useScheduleHelpModal = () => {
     selectedSubject,
     showConfirmation,
     handleChangeDate,
+    handleChangeDescription,
     handleChangeHour,
     handleChangeMonitor,
     handleChangeProfessor,

--- a/src/components/ScheduleHelpModal/index.tsx
+++ b/src/components/ScheduleHelpModal/index.tsx
@@ -15,6 +15,7 @@ import { FeedbackContainer } from './styles';
 type Props = {
   availableHours: string[];
   availableMonitors: TSubjectMonitor[];
+  description: string;
   isLoadingMonitorAvailableTimes: boolean;
   isScheduleLoading: boolean;
   isScheduleSuccess: boolean;
@@ -28,6 +29,7 @@ type Props = {
   subject?: TCompleteSubject;
   handleClose(): void;
   handleChangeDate(value: moment.Moment | null): void;
+  handleChangeDescription(e: React.ChangeEvent<HTMLInputElement>): void;
   handleChangeHour(event: SelectChangeEvent<string[]>): void;
   handleChangeMonitor(event: SelectChangeEvent<string[]>): void;
   handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
@@ -39,6 +41,7 @@ type Props = {
 const ScheduleHelpModal = ({
   availableHours,
   availableMonitors,
+  description,
   isLoadingMonitorAvailableTimes,
   isScheduleLoading,
   isScheduleSuccess,
@@ -51,6 +54,7 @@ const ScheduleHelpModal = ({
   subject,
   showConfirmation,
   handleChangeDate,
+  handleChangeDescription,
   handleChangeHour,
   handleChangeMonitor,
   handleChangeProfessor,
@@ -80,6 +84,7 @@ const ScheduleHelpModal = ({
           selectedDate={selectedDate}
           availableHours={availableHours}
           availableMonitors={availableMonitors}
+          description={description}
           selectedHourIndex={selectedHourIndex}
           selectedMonitorId={selectedMonitorId}
           selectedProfessorId={selectedProfessorId}
@@ -94,12 +99,14 @@ const ScheduleHelpModal = ({
       <FormScheduleModalContent
         availableHours={availableHours}
         availableMonitors={availableMonitors}
+        description={description}
         isLoadingMonitorAvailableTimes={isLoadingMonitorAvailableTimes}
         monitorAvailableTimes={monitorAvailableTimes}
         selectedDate={selectedDate}
         selectedHourIndex={selectedHourIndex}
         selectedMonitorId={selectedMonitorId}
         selectedProfessorId={selectedProfessorId}
+        handleChangeDescription={handleChangeDescription}
         handleChangeHour={handleChangeHour}
         handleChangeDate={handleChangeDate}
         handleChangeMonitor={handleChangeMonitor}

--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -8,6 +8,7 @@ import {
 
 type Props = {
   email: string;
+  description: string;
   linkedin?: string;
   whatsapp?: string;
   isMonitor: boolean;
@@ -17,6 +18,7 @@ type Props = {
 
 const ConfirmedScheduleModalContent = ({
   email,
+  description,
   linkedin,
   whatsapp,
   isMonitor,
@@ -31,7 +33,7 @@ const ConfirmedScheduleModalContent = ({
     </Typography>
 
     <DataContainer>
-      <Label>E-mail:</Label>
+      <Label>E-mail</Label>
       <Typography variant="body2">{email}</Typography>
     </DataContainer>
 
@@ -43,6 +45,11 @@ const ConfirmedScheduleModalContent = ({
     <DataContainer>
       <Label>Whatsapp</Label>
       <Typography variant="body2">{whatsapp || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Descrição</Label>
+      <Typography variant="body2">{description || '-'}</Typography>
     </DataContainer>
 
     <ButtonsContainer>

--- a/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
@@ -14,6 +14,7 @@ type Props = {
   subject: string;
   start: Date;
   end: Date;
+  description: string;
   isMonitor: boolean;
   handleAccept(): void;
   handleClose(): void;
@@ -27,6 +28,7 @@ const PendingScheduleModalContent = ({
   start,
   end,
   isMonitor,
+  description,
   handleAccept,
   handleClose,
   handleRefuse,
@@ -62,6 +64,11 @@ const PendingScheduleModalContent = ({
     <DataContainer>
       <Label>Horário</Label>
       <Typography variant="body2">{`${start.toLocaleTimeString()} até ${end.toLocaleTimeString()}`}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Descrição</Label>
+      <Typography variant="body2">{description || '-'}</Typography>
     </DataContainer>
 
     {isMonitor ? (

--- a/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
@@ -71,6 +71,7 @@ const ScheduleDetailsModal = ({
       {modalType === ScheduleDetailsModalType.CONFIRMED ? (
         <ConfirmedScheduleModalContent
           email={userData.email}
+          description={schedule.description}
           linkedin={userData.linkedin}
           whatsapp={userData.whatsapp}
           isMonitor={schedule.is_monitoring}
@@ -83,6 +84,7 @@ const ScheduleDetailsModal = ({
       {modalType === ScheduleDetailsModalType.PENDING ? (
         <PendingScheduleModalContent
           name={userData.name}
+          description={schedule.description}
           course={userData.course}
           subject={schedule.monitor.subject.name}
           start={schedule.start}

--- a/src/screens/subjectDetails/index.tsx
+++ b/src/screens/subjectDetails/index.tsx
@@ -40,6 +40,7 @@ const SubjectDetails = () => {
   const {
     availableHours,
     availableMonitors,
+    description,
     isLoadingMonitorAvailableTimes,
     isScheduleLoading,
     isScheduleSuccess,
@@ -48,6 +49,7 @@ const SubjectDetails = () => {
     selectedDate,
     selectedMonitorId,
     selectedProfessorId: selectedScheduleProfessorId,
+    handleChangeDescription,
     handleChangeHour,
     handleChangeProfessor,
     handleChangeMonitor,
@@ -183,11 +185,13 @@ const SubjectDetails = () => {
       <ScheduleHelpModal
         availableHours={availableHours}
         availableMonitors={availableMonitors}
+        description={description}
         isLoadingMonitorAvailableTimes={isLoadingMonitorAvailableTimes}
         isScheduleLoading={isScheduleLoading}
         isScheduleSuccess={isScheduleSuccess}
         monitorAvailableTimes={monitorAvailableTimes}
         selectedDate={selectedDate}
+        handleChangeDescription={handleChangeDescription}
         selectedHourIndex={selectedHourIndex}
         selectedMonitorId={selectedMonitorId}
         selectedProfessorId={selectedScheduleProfessorId}

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -50,6 +50,7 @@ const Subjects = () => {
   const {
     availableHours,
     availableMonitors,
+    description,
     isLoadingMonitorAvailableTimes,
     isScheduleLoading,
     isScheduleSuccess,
@@ -58,6 +59,7 @@ const Subjects = () => {
     selectedDate,
     selectedMonitorId,
     selectedProfessorId,
+    handleChangeDescription,
     handleChangeHour,
     handleChangeProfessor,
     handleChangeMonitor,
@@ -95,6 +97,7 @@ const Subjects = () => {
       <ScheduleHelpModal
         availableHours={availableHours}
         availableMonitors={availableMonitors}
+        description={description}
         isLoadingMonitorAvailableTimes={isLoadingMonitorAvailableTimes}
         isScheduleLoading={isScheduleLoading}
         isScheduleSuccess={isScheduleSuccess}
@@ -106,6 +109,7 @@ const Subjects = () => {
         showConfirmation={showConfirmation}
         handleChangeHour={handleChangeHour}
         handleChangeDate={handleChangeDate}
+        handleChangeDescription={handleChangeDescription}
         handleChangeMonitor={handleChangeMonitor}
         handleChangeProfessor={handleChangeProfessor}
         handleEditData={handleEditData}

--- a/src/service/requests/useGetSchedulesRequest/types.ts
+++ b/src/service/requests/useGetSchedulesRequest/types.ts
@@ -40,6 +40,7 @@ export type TSchedules = {
   id: number;
   start: Date;
   end: Date;
+  description: string;
   id_status: number;
   student_id: number;
   monitor_id: number;

--- a/src/service/requests/useScheduleRequest/index.ts
+++ b/src/service/requests/useScheduleRequest/index.ts
@@ -8,7 +8,12 @@ const useScheduleRequest = () => {
   const [error, setError] = useState<string>();
   const [isSuccess, setIsSuccess] = useState(false);
 
-  const schedule = async (monitorId: number, start: string, end: string) => {
+  const schedule = async (
+    monitorId: number,
+    start: string,
+    end: string,
+    description: string
+  ) => {
     setIsLoading(true);
     setIsSuccess(false);
     setError(undefined);
@@ -17,6 +22,7 @@ const useScheduleRequest = () => {
       await api.post(`/student/${monitorId}/schedule`, {
         start,
         end,
+        description,
       });
 
       setIsSuccess(true);


### PR DESCRIPTION
# Descrição

- Cria input para o aluno inserir a descrição do agendamento.
- Envia campo `description` ao agendar ajuda.
- Mostra descrição nas modais de agendamento confirmado, pendente e aguardando confirmação.

# Setup

- [ ] Altere a env para apontar para o backend de staging
- [ ] `yarn start`
- [ ] Logue com a conta `nabson.paiva@icomp.ufam.edu.br` | `12345678`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Agendar ajuda com descrição

- [ ] Entre na tela da disciplina Desenvolvimento De Aplicativos Para Dispositivos Móveis
- [ ] Agende uma ajuda com qualquer monitor e preencha o campo de descrição.
- [ ] Verifique se a modal está de acordo com o **[Figma](https://www.figma.com/file/rtjsSZDBG51KFRigOgGo3E/Super-Monitoria---Componentes-e-Branding-v1.0?node-id=3344-8897&t=8YB55adDV7WtciMY-0)**.
- [ ] Pressione concluir agendamento na modal de agendar e verifique que a descrição é mostrada na modal de confirmar dados.
- [ ] Realize o agendamento e verifique se deu certo.
- [ ] Vá para a tela de agendamentos e clique no agendamento que criou nos passos acima.
- [ ] Verifique se a descrição informada está sendo mostrada.

# Para Deploy

- Esta PR depende da alteração no backend de add o campo de descrição no agendamento
