### PR TITLE
fix: Filtra prof por Id e não por responsibleId

### DIFF
--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -86,7 +86,7 @@ const FormScheduleModalContent = ({
           ) : (
             <Typography>
               {subject.responsables.find(
-                (prof) => prof.id === Number(selected[0])
+                (prof) => prof.professor.user.id === Number(selected[0])
               )?.professor.user.name || ''}
             </Typography>
           )
@@ -97,7 +97,10 @@ const FormScheduleModalContent = ({
             Selecionar Professor(a)
           </MenuItem>,
           ...subject.responsables.map((professor) => (
-            <MenuItem key={professor.id} value={professor.id}>
+            <MenuItem
+              key={professor.professor.user.id}
+              value={professor.professor.user.id}
+            >
               {professor.professor.user.name}
             </MenuItem>
           )),


### PR DESCRIPTION
# Descrição

Ao clicar em um monitor na tela de detalhes de disciplina para fazer um agendamento, o campo de professor na modal está vazio ou mostra o professor errado.

# Em casos de bugfix

- Qual foi a causa do bug?
  - O campo estava buscando o professor pelo `responsibleId`, não pelo `professorId`.
- O que foi feito para corrigi-lo?
  - Acessa o `professorId` para buscar o professor selecionado e mostrar no campo.
