### PR TITLE
fix: Trata a tentativa de salvar com dados faltando

### DIFF
--- a/src/components/monitorAvailabilityModal/hooks/useMonitorAvailabilityModal.ts
+++ b/src/components/monitorAvailabilityModal/hooks/useMonitorAvailabilityModal.ts
@@ -34,7 +34,7 @@ const useMonitorAvailabilityModal = () => {
       (weekDay) => weekDay.isSelected
     );
 
-    const availability: TAvailability[] = selectedWeekDays.map((weekDay) => ({
+    return selectedWeekDays.map((weekDay) => ({
       weekDay: weekDay.weekDay,
       hours: [
         {
@@ -47,28 +47,22 @@ const useMonitorAvailabilityModal = () => {
         },
       ],
     }));
-    return availability;
   }, [weekDayAvailability, sameAvailability]);
 
-  const dayIsSelected: boolean = useMemo(() => {
-    return availabilities.length ? true : false;
-  }, [availabilities]);
+  const dayIsSelected = useMemo(
+    () => !!availabilities.length,
+    [availabilities]
+  );
 
   const hoursIsSelected: boolean = useMemo(() => {
-    let hourMissing = true;
     if (dayIsSelected) {
-      availabilities.map((day) => {
-        if (
-          day.hours[0].start === undefined ||
-          day.hours[0].end === undefined
-        ) {
-          hourMissing = true;
-          return;
+      for (const day of availabilities) {
+        if (!day.hours[0].start || !day.hours[0].end) {
+          return false;
         }
-        hourMissing = false;
-      });
+      }
     }
-    return !hourMissing;
+    return true;
   }, [availabilities]);
 
   const handleOpenModal = () => {

--- a/src/components/monitorAvailabilityModal/index.tsx
+++ b/src/components/monitorAvailabilityModal/index.tsx
@@ -32,6 +32,8 @@ type Props = {
   isOpen: boolean;
   sameAvailability: TWeekDayAvailabilityState;
   weekDayAvailability: TWeekDayAvailabilityState[];
+  dayIsSelected: boolean;
+  hoursIsSelected: boolean;
   handleCloseModal(): void;
   handleFromHourChange(event: SelectChangeEvent<string>): void;
   handleFromSameHourChange(event: SelectChangeEvent<string>): void;
@@ -50,6 +52,8 @@ const MonitorAvailabilityModal = ({
   isOpen,
   sameAvailability,
   weekDayAvailability,
+  dayIsSelected,
+  hoursIsSelected,
   handleCloseModal,
   handleFromHourChange,
   handleFromSameHourChange,
@@ -129,7 +133,7 @@ const MonitorAvailabilityModal = ({
               />
             </SwitchContainer>
 
-            {sameAvailability.isSelected ? (
+            {sameAvailability.isSelected && dayIsSelected ? (
               <SelectContainer isSelected={sameAvailability.isSelected}>
                 <HourSelect
                   name={sameAvailability.name}
@@ -161,7 +165,12 @@ const MonitorAvailabilityModal = ({
 
         <ButtonContainer>
           <ButtonCancel onClick={handleCloseModal}>Cancelar</ButtonCancel>
-          <ButtonSave onClick={handleSaveAvailability}>Salvar</ButtonSave>
+          <ButtonSave
+            disabled={!(dayIsSelected && hoursIsSelected)}
+            onClick={handleSaveAvailability}
+          >
+            Salvar
+          </ButtonSave>
         </ButtonContainer>
       </CardContainer>
     );


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Trata a possibilidade do usuário tentar salvar a disponibilidade com algum dos dados faltando. Desabilita o botão de salvar enquanto não tiver todos os dados preenchidos e só exibe a escolha de horas depois de um dia ter sido selecionado.

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Fazer login em uma conta de monitor
- [ ] Abrir modal de gerenciar disponibilidade
- [ ] Verificar se o botão salvar está desabilitado enquanto houver dados faltando
- [ ] Verificar que a escolha de horário é exibido se não houver um dia selecionado