### PR TITLE
chore: Altera rota / para ser a landing page

### DIFF
--- a/src/components/breadcrumbs/styles.ts
+++ b/src/components/breadcrumbs/styles.ts
@@ -2,6 +2,7 @@ import { Breadcrumbs, Link as MUILink, Typography } from '@mui/material';
 import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 import theme from '../../utils/theme';
+import { SCREENS } from '../../utils/screens';
 
 export const StyledBreadcrumbs = styled(Breadcrumbs).attrs({
   separator: '>',
@@ -19,7 +20,7 @@ export const Link = styled(MUILink).attrs((props) => ({
   underline: 'hover',
   variant: 'caption',
   component: NavLink,
-  to: props.href || '/',
+  to: props.href || SCREENS.LOGIN,
 }))`
   color: ${theme.palette.grey[600]} !important;
 `;

--- a/src/utils/screens.ts
+++ b/src/utils/screens.ts
@@ -3,14 +3,14 @@ export const SCREENS = {
   SCHEDULES_HISTORIC: '/schedules-historic',
   CODE_VERIFICATION: '/code-verification',
   HOME: '/subjects',
-  LOGIN: '/',
+  LOGIN: '/login',
   REGISTER: '/register',
   CREATE_STUDENT: '/register/student',
   CREATE_PROFESSOR: '/register/professor',
   SUBJECTS: '/subjects',
   SUBJECT_DETAILS: '/subjects/:id',
   MONITOR_REQUESTS: '/monitor-requests',
-  LANDING_PAGE: '/about',
+  LANDING_PAGE: '/',
 };
 
 export const NOT_LOGGED_SCREENS = [


### PR DESCRIPTION
# Descrição

**[[FRONT] Alterar nome das telas](https://computero.atlassian.net/browse/DS-148)**

Altera a rota `/` para mostrar a landing page e não mais o login. O login será mostrado na tela `/login`.

# Setup

- [x] Altere a variável de ambiente para apontar ao backend de `staging`
- [x] `yarn start`

# Cenários

## 1. Login e Logout

- [x] Verifique se a aplicação abriu na landing page e não no login
- [x] Pressione o botão `Faça seu login` e verifique se foi redirecionado ao login
- [x] Faça login e verifique se ele deu certo
- [x] Pressione o botão de sair e verifique se foi redirecionado ao login

## 2. Usuário não logado

- [x] Faça logout
- [x] Tente acessar uma tela que requer um usuário logado, como a `/subjects`
- [x] Verifique se foi redirecionado para a tela de login `/login`
