### PR TITLE
feat: Adiciona assunto na modal de agendamento

### DIFF
--- a/src/components/ScheduleHelpModal/components/ConfirmScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/ConfirmScheduleModalContent/index.tsx
@@ -6,6 +6,7 @@ import {
 } from '../../../../service/requests/useGetSubject/types';
 import { ButtonsContainer, StyledButton } from '../../styles';
 import { DataContainer, Label } from './styles';
+import { TTopicValue } from '../../types';
 
 type Props = {
   availableHours: string[];
@@ -16,6 +17,7 @@ type Props = {
   selectedProfessorId: number;
   selectedMonitorId: number;
   subject: TCompleteSubject;
+  topic: TTopicValue | null;
   handleConfirmSchedule(): void;
   handleEditData(): void;
 };
@@ -29,6 +31,7 @@ const ConfirmScheduleModalContent = ({
   selectedMonitorId,
   selectedProfessorId,
   subject,
+  topic,
   handleConfirmSchedule,
   handleEditData,
 }: Props) => {
@@ -73,6 +76,11 @@ const ConfirmScheduleModalContent = ({
         value: availableHours[selectedHourIndex],
       });
     }
+
+    data.push({
+      label: 'Assunto',
+      value: topic?.label || '-',
+    });
 
     data.push({
       label: 'Descrição',

--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -195,8 +195,6 @@ const FormScheduleModalContent = ({
         onChange={handleChangeTopicValue}
       />
 
-      {console.log(selectedTopic, topicInputValue, options)}
-
       <DescriptionContainer>
         <DescriptionTextField
           value={description}

--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -1,21 +1,18 @@
 import {
+  Autocomplete,
+  CircularProgress,
   FormHelperText,
   MenuItem,
   Select,
-  SelectChangeEvent,
+  TextField as TextFieldMUI,
   Typography,
   useMediaQuery,
 } from '@mui/material';
 import { DesktopDatePicker } from '@mui/x-date-pickers';
-import moment from 'moment';
-import { TMonitorAvailableTime } from '../../../../service/requests/useGetMonitorAvailableTimesRequest/types';
-import {
-  TCompleteSubject,
-  TSubjectMonitor,
-} from '../../../../service/requests/useGetSubject/types';
 import theme from '../../../../utils/theme';
 import { TextField } from '../../../textField';
 import { ButtonsContainer, StyledButton } from '../../styles';
+import { TUseSchedulesHook } from '../../types';
 import {
   DateFieldsContainer,
   DateTextField,
@@ -23,26 +20,6 @@ import {
   DescriptionTextField,
   Placeholder,
 } from './styles';
-
-type Props = {
-  availableHours: string[];
-  availableMonitors: TSubjectMonitor[];
-  description: string;
-  isLoadingMonitorAvailableTimes: boolean;
-  monitorAvailableTimes?: TMonitorAvailableTime[];
-  selectedDate: moment.Moment | null;
-  selectedHourIndex: number;
-  selectedProfessorId: number;
-  selectedMonitorId: number;
-  subject: TCompleteSubject;
-  handleClose(): void;
-  handleChangeDate(value: moment.Moment | null): void;
-  handleChangeDescription(e: React.ChangeEvent<HTMLInputElement>): void;
-  handleChangeHour(event: SelectChangeEvent<string[]>): void;
-  handleChangeMonitor(event: SelectChangeEvent<string[]>): void;
-  handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
-  handleShowConfirmation(): void;
-};
 
 const FormScheduleModalContent = ({
   availableHours,
@@ -55,6 +32,12 @@ const FormScheduleModalContent = ({
   selectedMonitorId,
   selectedProfessorId,
   subject,
+  options,
+  selectedTopic,
+  topicInputValue,
+  isLoadingTopics,
+  handleChangeTopicInput,
+  handleChangeTopicValue,
   handleChangeDate,
   handleChangeDescription,
   handleChangeHour,
@@ -62,7 +45,7 @@ const FormScheduleModalContent = ({
   handleChangeProfessor,
   handleClose,
   handleShowConfirmation,
-}: Props) => {
+}: TUseSchedulesHook) => {
   const shouldExpandDescriptionLines = useMediaQuery(
     theme.breakpoints.down('sm')
   );
@@ -184,11 +167,40 @@ const FormScheduleModalContent = ({
           ]}
         </Select>
       </DateFieldsContainer>
+      <Autocomplete
+        options={options}
+        getOptionLabel={(option) => option.label}
+        disabled={selectedHourIndex === -1}
+        renderInput={(params) => (
+          <TextFieldMUI
+            {...params}
+            placeholder="Buscar assunto"
+            InputProps={{
+              ...params.InputProps,
+              endAdornment: (
+                <>
+                  {isLoadingTopics && (
+                    <CircularProgress color="primary" size={20} />
+                  )}{' '}
+                  {params.InputProps.endAdornment}
+                </>
+              ),
+            }}
+          />
+        )}
+        noOptionsText="Carregando..."
+        value={selectedTopic}
+        inputValue={topicInputValue}
+        onInputChange={handleChangeTopicInput}
+        onChange={handleChangeTopicValue}
+      />
+
+      {console.log(selectedTopic, topicInputValue, options)}
 
       <DescriptionContainer>
         <DescriptionTextField
-          disabled={selectedHourIndex === -1}
           value={description}
+          disabled={selectedHourIndex === -1}
           onChange={handleChangeDescription}
           minRows={shouldExpandDescriptionLines ? 10 : 4}
         />

--- a/src/components/ScheduleHelpModal/hooks/useTopics.ts
+++ b/src/components/ScheduleHelpModal/hooks/useTopics.ts
@@ -1,0 +1,116 @@
+import { useEffect, useMemo, useState } from 'react';
+import useGetTopicsRequest from '../../../service/requests/useGetTopicsRequest';
+import { useSnackBar } from '../../../utils/renderSnackBar';
+import { TTopicValue } from '../types';
+
+const useTopics = () => {
+  const { showErrorSnackBar } = useSnackBar();
+
+  const {
+    response,
+    error,
+    getTopics,
+    isLoading: isLoadingTopics,
+  } = useGetTopicsRequest();
+
+  const [topicInputValue, setTopicInputValue] = useState('');
+  const [selectedTopic, setSelectedTopic] = useState<TTopicValue | null>(null);
+
+  const formatScheduleTopicName = (name: string): string => {
+    return name
+      .trim()
+      .split(/\s+/)
+      .map((word) => {
+        let formatedString: string = word.charAt(0).toUpperCase();
+
+        for (let i = 1; i < word.length; i++) {
+          if (word[i - 1] == '-')
+            formatedString = formatedString + word[i].toUpperCase();
+          else formatedString = formatedString + word[i].toLowerCase();
+        }
+
+        return formatedString;
+      })
+      .join(' ');
+  };
+
+  const options: TTopicValue[] = useMemo(() => {
+    if (!response) return [];
+
+    if (!response.data.length) {
+      const formatedInputValue = formatScheduleTopicName(topicInputValue);
+
+      const auxiliarTopicValue: TTopicValue = {
+        isNew: true,
+        inputValue: formatedInputValue,
+        label: `Adicionar assunto "${formatedInputValue}"`,
+      };
+
+      return [auxiliarTopicValue];
+    }
+
+    return response.data.map((topic) => ({
+      id: topic.id,
+      isNew: false,
+      inputValue: topic.name,
+      label: topic.name,
+    }));
+  }, [response]);
+
+  const handleChangeTopicInput = (
+    event: React.SyntheticEvent<Element, Event>,
+    newTopicInputValue: string
+  ) => {
+    setTopicInputValue(newTopicInputValue);
+  };
+
+  const handleChangeTopicValue = (
+    event: React.SyntheticEvent<Element, Event>,
+    newTopicValue: TTopicValue | null
+  ) => {
+    if (newTopicValue && newTopicValue.isNew) {
+      setSelectedTopic({
+        ...newTopicValue,
+        label: newTopicValue.inputValue,
+      });
+      return;
+    }
+
+    setSelectedTopic(newTopicValue);
+  };
+
+  const resetStates = () => {
+    setTopicInputValue(``);
+    setSelectedTopic(null);
+  };
+
+  useEffect(() => {
+    if (!topicInputValue) return;
+
+    const delayDebounceFn = setTimeout(() => {
+      void getTopics({ name: topicInputValue });
+    }, 1000);
+
+    return () => {
+      clearTimeout(delayDebounceFn);
+    };
+  }, [topicInputValue]);
+
+  useEffect(() => {
+    if (!error) return;
+
+    showErrorSnackBar(`Erro ao requisitar topicos: ${error}`);
+  }, [error]);
+
+  return {
+    selectedTopic,
+    options,
+    topicInputValue,
+    isLoadingTopics,
+    handleChangeTopicInput,
+    handleChangeTopicValue,
+    resetStates,
+  };
+};
+
+export default useTopics;

--- a/src/components/ScheduleHelpModal/index.tsx
+++ b/src/components/ScheduleHelpModal/index.tsx
@@ -1,42 +1,10 @@
-import { SelectChangeEvent } from '@mui/material';
-import moment from 'moment';
-import { TMonitorAvailableTime } from '../../service/requests/useGetMonitorAvailableTimesRequest/types';
-import {
-  TCompleteSubject,
-  TSubjectMonitor,
-} from '../../service/requests/useGetSubject/types';
 import LoadingAnimation from '../loadingAnimation';
 import Modal from '../modal';
-import ConfirmedScheduleModalContent from './components/ConfirmedScheduleModalContent';
 import ConfirmScheduleModalContent from './components/ConfirmScheduleModalContent';
+import ConfirmedScheduleModalContent from './components/ConfirmedScheduleModalContent';
 import FormScheduleModalContent from './components/FormScheduleModalContent';
 import { FeedbackContainer } from './styles';
-
-type Props = {
-  availableHours: string[];
-  availableMonitors: TSubjectMonitor[];
-  description: string;
-  isLoadingMonitorAvailableTimes: boolean;
-  isScheduleLoading: boolean;
-  isScheduleSuccess: boolean;
-  isOpen: boolean;
-  monitorAvailableTimes?: TMonitorAvailableTime[];
-  selectedDate: moment.Moment | null;
-  selectedHourIndex: number;
-  selectedProfessorId: number;
-  selectedMonitorId: number;
-  showConfirmation: boolean;
-  subject?: TCompleteSubject;
-  handleClose(): void;
-  handleChangeDate(value: moment.Moment | null): void;
-  handleChangeDescription(e: React.ChangeEvent<HTMLInputElement>): void;
-  handleChangeHour(event: SelectChangeEvent<string[]>): void;
-  handleChangeMonitor(event: SelectChangeEvent<string[]>): void;
-  handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
-  handleConfirmSchedule(): void;
-  handleEditData(): void;
-  handleShowConfirmation(): void;
-};
+import { TScheduleHelpModalProps } from './types';
 
 const ScheduleHelpModal = ({
   availableHours,
@@ -53,6 +21,12 @@ const ScheduleHelpModal = ({
   selectedProfessorId,
   subject,
   showConfirmation,
+  options,
+  selectedTopic,
+  topicInputValue,
+  isLoadingTopics,
+  handleChangeTopicInput,
+  handleChangeTopicValue,
   handleChangeDate,
   handleChangeDescription,
   handleChangeHour,
@@ -62,7 +36,7 @@ const ScheduleHelpModal = ({
   handleConfirmSchedule,
   handleEditData,
   handleShowConfirmation,
-}: Props) => {
+}: TScheduleHelpModalProps) => {
   if (!subject) return <></>;
 
   const renderContent = () => {
@@ -89,6 +63,7 @@ const ScheduleHelpModal = ({
           selectedMonitorId={selectedMonitorId}
           selectedProfessorId={selectedProfessorId}
           handleEditData={handleEditData}
+          topic={selectedTopic}
           subject={subject}
           handleConfirmSchedule={handleConfirmSchedule}
         />
@@ -97,6 +72,12 @@ const ScheduleHelpModal = ({
 
     return (
       <FormScheduleModalContent
+        isLoadingTopics={isLoadingTopics}
+        topicInputValue={topicInputValue}
+        handleChangeTopicInput={handleChangeTopicInput}
+        selectedTopic={selectedTopic}
+        handleChangeTopicValue={handleChangeTopicValue}
+        options={options}
         availableHours={availableHours}
         availableMonitors={availableMonitors}
         description={description}

--- a/src/components/ScheduleHelpModal/types.ts
+++ b/src/components/ScheduleHelpModal/types.ts
@@ -1,0 +1,55 @@
+import { SelectChangeEvent } from '@mui/material';
+import { TMonitorAvailableTime } from '../../service/requests/useGetMonitorAvailableTimesRequest/types';
+import {
+  TCompleteSubject,
+  TSubjectMonitor,
+} from '../../service/requests/useGetSubject/types';
+
+export type TTopicValue = {
+  id?: number;
+  isNew: boolean;
+  inputValue: string;
+  label: string;
+};
+
+export type TUseSchedulesHook = {
+  availableHours: string[];
+  availableMonitors: TSubjectMonitor[];
+  description: string;
+  isLoadingMonitorAvailableTimes: boolean;
+  monitorAvailableTimes?: TMonitorAvailableTime[];
+  selectedDate: moment.Moment | null;
+  selectedHourIndex: number;
+  selectedProfessorId: number;
+  selectedMonitorId: number;
+  subject: TCompleteSubject;
+  options: TTopicValue[];
+  selectedTopic: TTopicValue | null;
+  topicInputValue: string;
+  isLoadingTopics: boolean;
+  handleChangeTopicInput(
+    event: React.SyntheticEvent<Element, Event>,
+    newTopicInputValue: string
+  ): void;
+  handleChangeTopicValue(
+    event: React.SyntheticEvent<Element, Event>,
+    newInputValue: TTopicValue | null
+  ): void;
+  handleClose(): void;
+  handleChangeDate(value: moment.Moment | null): void;
+  handleChangeDescription(e: React.ChangeEvent<HTMLInputElement>): void;
+  handleChangeHour(event: SelectChangeEvent<string[]>): void;
+  handleChangeMonitor(event: SelectChangeEvent<string[]>): void;
+  handleChangeProfessor(event: SelectChangeEvent<string[]>): void;
+  handleShowConfirmation(): void;
+};
+
+export type TScheduleHelpModalProps = {
+  subject?: TCompleteSubject;
+  isScheduleLoading: boolean;
+  isScheduleSuccess: boolean;
+  isOpen: boolean;
+  showConfirmation: boolean;
+  handleConfirmSchedule(): void;
+  handleEditData(): void;
+} & Omit<TUseSchedulesHook, `subject`>;

--- a/src/screens/subjectDetails/index.tsx
+++ b/src/screens/subjectDetails/index.tsx
@@ -49,6 +49,10 @@ const SubjectDetails = () => {
     selectedDate,
     selectedMonitorId,
     selectedProfessorId: selectedScheduleProfessorId,
+    options,
+    selectedTopic,
+    isLoadingTopics,
+    handleChangeTopicValue,
     handleChangeDescription,
     handleChangeHour,
     handleChangeProfessor,
@@ -62,6 +66,8 @@ const SubjectDetails = () => {
     handleConfirmSchedule,
     handleEditData,
     handleShowConfirmation,
+    topicInputValue,
+    handleChangeTopicInput,
   } = useScheduleHelpModal();
 
   const {
@@ -183,6 +189,12 @@ const SubjectDetails = () => {
   return (
     <ContainerWithSidebar selectedSidebarItem={SidebarItemEnum.SUBJECTS}>
       <ScheduleHelpModal
+        isLoadingTopics={isLoadingTopics}
+        selectedTopic={selectedTopic}
+        topicInputValue={topicInputValue}
+        handleChangeTopicInput={handleChangeTopicInput}
+        handleChangeTopicValue={handleChangeTopicValue}
+        options={options}
         availableHours={availableHours}
         availableMonitors={availableMonitors}
         description={description}

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -59,6 +59,10 @@ const Subjects = () => {
     selectedDate,
     selectedMonitorId,
     selectedProfessorId,
+    options,
+    selectedTopic,
+    isLoadingTopics,
+    handleChangeTopicValue,
     handleChangeDescription,
     handleChangeHour,
     handleChangeProfessor,
@@ -72,6 +76,8 @@ const Subjects = () => {
     handleConfirmSchedule,
     handleEditData,
     handleShowConfirmation,
+    topicInputValue,
+    handleChangeTopicInput,
   } = useScheduleHelpModal();
 
   return (
@@ -95,6 +101,12 @@ const Subjects = () => {
         isRemoveProfessorModalOpen={isRemoveProfessorModalOpen}
       />
       <ScheduleHelpModal
+        isLoadingTopics={isLoadingTopics}
+        selectedTopic={selectedTopic}
+        topicInputValue={topicInputValue}
+        handleChangeTopicInput={handleChangeTopicInput}
+        handleChangeTopicValue={handleChangeTopicValue}
+        options={options}
         availableHours={availableHours}
         availableMonitors={availableMonitors}
         description={description}

--- a/src/service/requests/useAddTopicRequest/index.tsx
+++ b/src/service/requests/useAddTopicRequest/index.tsx
@@ -1,0 +1,49 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import { TGenerateCodeErrorResponse } from '../useGenerateCodeRequest/types';
+import { TAddTopicRequestParams, TTopic } from './types';
+
+const useAddTopicRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [data, setData] = useState<TTopic>();
+
+  const addTopic = async ({ name }: TAddTopicRequestParams) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    try {
+      const response = await api.post(`schedules/topics`, { name });
+
+      setData(response.data as TTopic);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TGenerateCodeErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during topics creation. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const resetStates = () => {
+    setIsLoading(false);
+    setData(undefined);
+    setError(undefined);
+  };
+
+  return {
+    isLoading,
+    data,
+    error,
+    addTopic,
+    resetStates,
+  };
+};
+
+export default useAddTopicRequest;

--- a/src/service/requests/useAddTopicRequest/types.ts
+++ b/src/service/requests/useAddTopicRequest/types.ts
@@ -1,0 +1,16 @@
+export type TTopic = {
+  id: number;
+  name: string;
+  token: string;
+  updated_at: Date;
+  created_at: Date;
+};
+
+export type TAddTopicRequestErrorResponse = {
+  statusCode: number;
+  message: string;
+};
+
+export type TAddTopicRequestParams = {
+  name: string;
+};

--- a/src/service/requests/useGetTopicsRequest/index.tsx
+++ b/src/service/requests/useGetTopicsRequest/index.tsx
@@ -1,0 +1,55 @@
+import { AxiosError } from 'axios';
+import { useState } from 'react';
+import api from '../../api';
+import {
+  TGetTopicRequestParams,
+  TGetTopicsRequestErrorResponse,
+  TGetTopicsRequestResponse,
+} from './types';
+
+const useGetTopicsRequest = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [response, setData] = useState<TGetTopicsRequestResponse>();
+
+  const getTopics = async ({
+    name,
+    page,
+    pageSize,
+  }: TGetTopicRequestParams) => {
+    setIsLoading(true);
+    setData(undefined);
+    setError(undefined);
+
+    const nameParam = name ? `&name=${name}` : ``;
+
+    try {
+      const response = await api.get(
+        `/schedules/topics?pageSize=${pageSize || 10}&page=${
+          page || 1
+        }${nameParam}`
+      );
+
+      setData(response.data as TGetTopicsRequestResponse);
+    } catch (error) {
+      const err = error as AxiosError;
+      const errorData = err.response?.data as TGetTopicsRequestErrorResponse;
+      const errorMessage = errorData?.message || 'Erro desconhecido';
+
+      console.error('Error during topics request. Error:', errorMessage);
+
+      setError(errorMessage);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    response,
+    error,
+    getTopics,
+  };
+};
+
+export default useGetTopicsRequest;

--- a/src/service/requests/useGetTopicsRequest/types.ts
+++ b/src/service/requests/useGetTopicsRequest/types.ts
@@ -1,0 +1,28 @@
+export type TTopic = {
+  id: number;
+  name: string;
+  token: string;
+  updated_at: Date;
+  created_at: Date;
+};
+
+export type TGetTopicsRequestResponse = {
+  data: TTopic[];
+  meta: {
+    current_page: number;
+    items_per_page: number;
+    total_pages: number;
+    total_items: number;
+  };
+};
+
+export type TGetTopicsRequestErrorResponse = {
+  statusCode: number;
+  message: string;
+};
+
+export type TGetTopicRequestParams = {
+  name?: string;
+  pageSize?: number;
+  page?: number;
+};

--- a/src/service/requests/useScheduleRequest/index.ts
+++ b/src/service/requests/useScheduleRequest/index.ts
@@ -12,7 +12,8 @@ const useScheduleRequest = () => {
     monitorId: number,
     start: string,
     end: string,
-    description: string
+    description: string,
+    topicId?: number
   ) => {
     setIsLoading(true);
     setIsSuccess(false);
@@ -22,6 +23,7 @@ const useScheduleRequest = () => {
       await api.post(`/student/${monitorId}/schedule`, {
         start,
         end,
+        topicId,
         description,
       });
 

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -15,6 +15,31 @@ const breakpoints = {
 };
 
 const components = {
+  MuiAutocomplete: {
+    styleOverrides: {
+      inputRoot: {
+        borderRadius: '12px',
+      },
+      noOptions: {
+        backgroundColor: 'white',
+      },
+      listbox: {
+        maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+        backgroundColor: 'white',
+      },
+      popper: {
+        boxShadow: '0px 0px 12px rgba(0, 0, 0, 0.1)',
+      },
+      option: {
+        '&[aria-selected="true"]': {
+          backgroundColor: '#eeeeee !important',
+          '&:hover': {
+            backgroundColor: '#e0e0e0 !important',
+          },
+        },
+      },
+    },
+  },
   MuiSelect: {
     defaultProps: {
       MenuProps: {


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Adiciona o campo de assunto na modal de agendamento

# Setup

- [ ] yarn start

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Assunto no campo da modal

- [ ] **Antes de tudo, certifique-se que o ambiente de backend que voce esta utilizando tenha um monitor com horarios disponiveis em alguma disciplina**
- [ ] Inicie a aplicacao e faca login como **aluno**
- [ ] Na area de disciplinas, clique no botao de agendar para abrir a modal de agendamentos
- [ ] Preencha com as informacoes de professor, monitor, horario
- [ ] Primeiramente, insira um assunto que nao exista dentro do seu ambiente e complete o agendamento. Verifique se o agendamento e o assunto foram criados corretamente
- [ ] Em seguida, insira um assunto ja existente dentro do seu ambiente e complete o agendamento. Verifique se o agendamento foi criado corretamente
- [ ] Por fim, nao insira nenhum assunto e complete o agendamento. Verifique se o agendamento foi criado corretamente.
- [ ] Para todos os casos, verifique se a responsividade atende aos padroes propostos no Figma. 
