### PR TITLE
chore: Remove validação de e-mail institucional

### DIFF
--- a/src/screens/registerProfessor/components/FormRegister/index.tsx
+++ b/src/screens/registerProfessor/components/FormRegister/index.tsx
@@ -118,7 +118,7 @@ const FormRegister = () => {
                     error={!!emailError}
                     id="email"
                     name="email"
-                    placeholder="E-mail do IComp, Super ou UFAM*"
+                    placeholder="E-mail*"
                     onBlur={() => setEmailError(validateEmail(email))}
                     onChange={handleEmailChange}
                   />

--- a/src/screens/registerStudent/components/StartStudentRegister/index.tsx
+++ b/src/screens/registerStudent/components/StartStudentRegister/index.tsx
@@ -99,7 +99,7 @@ const StartStudentRegister = ({
             id="email"
             name="email"
             onChange={handleEmailChange}
-            placeholder="E-mail IComp, Super ou UFAM*"
+            placeholder="E-mail*"
           />
           <EmailError />
         </StyledFormBox>

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -10,30 +10,16 @@ export const validateName = (name: string): string => {
 };
 
 export const validateEmail = (email: string): string => {
-  if (!email || email.indexOf('@') === -1) return 'E-mail inválido!';
-
-  if (
-    email.indexOf('@icomp.ufam.edu.br') === -1 &&
-    email.indexOf('@super.ufam.edu.br') === -1 &&
-    email.indexOf('@ufam.edu.br') === -1
-  )
-    return 'Este e-mail não pertence ao domínio do IComp, SUPER ou UFAM!';
+  if (!email || email.indexOf('@') === -1) return 'Informe um e-mail válido!';
 
   if (email.split('@')[0].length < 3 || email.split('@')[0].length > 20)
-    return 'Informe um e-mail válido!';
-
-  const reIcomp = /^([\w.]{3,20})@icomp.ufam.edu.br$/gm;
-  const reSuper = /^([\w.]{3,20})@super.ufam.edu.br$/gm;
-  const reUfam = /^([\w.]{3,20})@ufam.edu.br$/gm;
-
-  if (!reIcomp.test(email) && !reSuper.test(email) && !reUfam.test(email))
     return 'Informe um e-mail válido!';
 
   return '';
 };
 
 export const validateContactEmail = (email: string): string => {
-  if (email && email.indexOf('@') === -1) return 'E-mail inválido!';
+  if (email && email.indexOf('@') === -1) return 'Informe um e-mail válido!';
 
   if (
     email &&


### PR DESCRIPTION
# Descrição
<!-- Coloque aqui o card que originou esta PR -->
[📌 Remover validação de e-mail institucional](https://computero.atlassian.net/browse/DS-198)

Remove a validação de e-mail que permite que apenas e-mail com domínio icomp, super ou ufam se cadastrem no sistema.

# Setup

- [x] Altere o .env para apontar para stg.
- [x] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Validação no formulário

- [x] Entre na tela de cadastro de aluno e informe um e-mail que não seja institucional
- [x] Pressione o botão de continuar e verifique que não foi mostrado o erro de e-mail inválido
