### PR TITLE
feat: Adiciona assunto nas modals de detalhes de agendamento

### DIFF
--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -8,6 +8,7 @@ import {
 
 type Props = {
   email: string;
+  topic: string;
   description: string;
   linkedin?: string;
   whatsapp?: string;
@@ -18,6 +19,7 @@ type Props = {
 
 const ConfirmedScheduleModalContent = ({
   email,
+  topic,
   description,
   linkedin,
   whatsapp,
@@ -33,6 +35,16 @@ const ConfirmedScheduleModalContent = ({
     </Typography>
 
     <DataContainer>
+      <Label>Assunto</Label>
+      <Typography variant="body2">{topic || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Descrição</Label>
+      <Typography variant="body2">{description || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
       <Label>E-mail</Label>
       <Typography variant="body2">{email}</Typography>
     </DataContainer>
@@ -45,11 +57,6 @@ const ConfirmedScheduleModalContent = ({
     <DataContainer>
       <Label>Whatsapp</Label>
       <Typography variant="body2">{whatsapp || '-'}</Typography>
-    </DataContainer>
-
-    <DataContainer>
-      <Label>Descrição</Label>
-      <Typography variant="body2">{description || '-'}</Typography>
     </DataContainer>
 
     <ButtonsContainer>

--- a/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   end: Date;
   description: string;
   isMonitor: boolean;
+  topic: string;
   handleAccept(): void;
   handleClose(): void;
   handleRefuse(): void;
@@ -29,6 +30,7 @@ const PendingScheduleModalContent = ({
   end,
   isMonitor,
   description,
+  topic,
   handleAccept,
   handleClose,
   handleRefuse,
@@ -57,6 +59,16 @@ const PendingScheduleModalContent = ({
     </DataContainer>
 
     <DataContainer>
+      <Label>Assunto</Label>
+      <Typography variant="body2">{topic || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Descrição</Label>
+      <Typography variant="body2">{description || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
       <Label>Data</Label>
       <Typography variant="body2">{start.toLocaleDateString()}</Typography>
     </DataContainer>
@@ -64,11 +76,6 @@ const PendingScheduleModalContent = ({
     <DataContainer>
       <Label>Horário</Label>
       <Typography variant="body2">{`${start.toLocaleTimeString()} até ${end.toLocaleTimeString()}`}</Typography>
-    </DataContainer>
-
-    <DataContainer>
-      <Label>Descrição</Label>
-      <Typography variant="body2">{description || '-'}</Typography>
     </DataContainer>
 
     {isMonitor ? (

--- a/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
@@ -70,6 +70,7 @@ const ScheduleDetailsModal = ({
       )}
       {modalType === ScheduleDetailsModalType.CONFIRMED ? (
         <ConfirmedScheduleModalContent
+          topic={schedule.ScheduleTopics.name}
           email={userData.email}
           description={schedule.description}
           linkedin={userData.linkedin}
@@ -90,6 +91,7 @@ const ScheduleDetailsModal = ({
           start={schedule.start}
           end={schedule.end}
           isMonitor={schedule.is_monitoring}
+          topic={schedule.ScheduleTopics.name}
           handleAccept={handleAccept}
           handleClose={handleClose}
           handleRefuse={handleRefuse}

--- a/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
@@ -10,7 +10,6 @@ type Props = {
 
 const ScheduleDetailsModal = ({ schedule, isOpen, handleClose }: Props) => {
   if (!schedule) return <></>;
-
   const startTime = schedule.startDate.toTimeString().substring(0, 5);
   const endTime = schedule.endDate.toTimeString().substring(0, 5);
   const date = schedule.startDate.toLocaleDateString('pt-br');
@@ -21,6 +20,8 @@ const ScheduleDetailsModal = ({ schedule, isOpen, handleClose }: Props) => {
         student={`${schedule.student.enrollment} - ${schedule.student.name}`}
         course={schedule.subject.course.name}
         subject={schedule.subject.name}
+        topic={schedule.topic.name}
+        description={schedule.description}
         monitor={`${schedule.monitor.enrollment} - ${schedule.monitor.name}`}
         professor={schedule.responsibleProfessor.name}
         date={date}

--- a/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
@@ -10,6 +10,8 @@ type Props = {
   student: string;
   course: string;
   subject: string;
+  topic: string;
+  description: string;
   monitor: string;
   professor: string;
   date: string;
@@ -21,6 +23,8 @@ const ScheduleHistoricModal = ({
   course,
   date,
   monitor,
+  topic,
+  description,
   professor,
   schedule,
   student,
@@ -46,6 +50,16 @@ const ScheduleHistoricModal = ({
     <DataContainer>
       <Label>Disciplina</Label>
       <Typography variant="body2">{subject}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Assunto</Label>
+      <Typography variant="body2">{topic || '-'}</Typography>
+    </DataContainer>
+
+    <DataContainer>
+      <Label>Descrição</Label>
+      <Typography variant="body2">{description || '-'}</Typography>
     </DataContainer>
 
     <DataContainer>

--- a/src/service/requests/useGetSchedulesHistoricRequest/types.ts
+++ b/src/service/requests/useGetSchedulesHistoricRequest/types.ts
@@ -47,6 +47,13 @@ export type TSchedules = {
   student: TStudent;
   responsibleProfessor: TResponsibleProfessor;
   subject: TSubject;
+  topic: TScheduleTopic;
+  description: string;
+};
+
+export type TScheduleTopic = {
+  id: number;
+  name: string;
 };
 
 export type TGetSchedulesHistoricRequestResponse = {

--- a/src/service/requests/useGetSchedulesRequest/types.ts
+++ b/src/service/requests/useGetSchedulesRequest/types.ts
@@ -47,6 +47,13 @@ export type TSchedules = {
   monitor: TMonitor;
   student: TStudent;
   is_monitoring: boolean;
+  schedule_topic_id: number;
+  ScheduleTopics: TScheduleTopic;
+};
+
+export type TScheduleTopic = {
+  id: number;
+  name: string;
 };
 
 export type TGetSchedulesRequestResponse = {


### PR DESCRIPTION
# Descrição

- Adiciona o campo de assunto e descrição nas modals de detalhe de agendamento na tela de agendamentos e na tela histórico do coordenador
# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acessar tela de agendamentos 
- [ ] Clicar em um agendamento pendente ou confirmado
- [ ] Verificar a presença da informação 'Assunto' e 'Descrição'

## 1. Cenário B**

- [ ] Acessar conta de coordenador
- [ ] Acessar tela de histórico
- [ ] Clicar em um agendamento
- [ ] Verificar a presença da informação 'Assunto' e 'Descrição'
