### PR TITLE
fix: Altera email de suporte na landing page

### DIFF
--- a/src/components/termsConsentModal/index.tsx
+++ b/src/components/termsConsentModal/index.tsx
@@ -57,7 +57,7 @@ const TermConsentModal = ({ isOpen, handleCloseModal }: Props) => {
             </StyledTypography>
             <StyledTypography>
               Estamos disponíveis para contato através do e-mail:
-              noreply-monitoria@icomp.ufam.edu.br
+              suportemonitoria@icomp.ufam.edu.br
             </StyledTypography>
             <StyledTypography>
               Utilizamos tais dados com os seguintes objetivos: <br />· Para o

--- a/src/screens/landingPage/components/turnIntoMonitor/index.tsx
+++ b/src/screens/landingPage/components/turnIntoMonitor/index.tsx
@@ -50,7 +50,7 @@ const TurnIntoMonitor = () => {
         <FooterContainer>
           <DoubtsTypography variant="body1" color={'white'}>
             Em caso de dúvidas, reclamações ou sugestões, entre em contato
-            conosco através do e-mail: noreply-monitoria@icomp.ufam.edu.br
+            conosco através do e-mail: suportemonitoria@icomp.ufam.edu.br
           </DoubtsTypography>
           <Typography variant="body1" color={'white'}>
             Super Monitoria, 2023


### PR DESCRIPTION
# Descrição

- Altera o email de suporte na landing page para `suportemonitoria@icomp.ufam.edu.br`

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acessar a landing page
- [ ] Verificar se o email do suporte foi alterado
