### PR TITLE
fix: Remove retorno do useEffect

### DIFF
--- a/src/components/ScheduleHelpModal/hooks/useTopics.ts
+++ b/src/components/ScheduleHelpModal/hooks/useTopics.ts
@@ -85,8 +85,6 @@ const useTopics = () => {
   };
 
   useEffect(() => {
-    if (!topicInputValue) return;
-
     const delayDebounceFn = setTimeout(() => {
       void getTopics({ name: topicInputValue });
     }, 1000);


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Corrige bug de lista de assuntos carregando para sempre

# Em casos de bugfix

- O hook que fazia fetch dos dados da lista nao completava a requisicao se o topicInput estivesse vazio. Como ele ja comeca vazio esse loading nao ia acabar.
- Para resolver apenas removi o trecho de codigo que contem esse retorno da requisicao no hook

# Setup

- [ ] yarn start

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Faca login como aluno e clique para agendar uma monitoria em uma disciplina com monitor
- [ ] Apos colocar todos os dados, verifique se a lista de assuntos nao esta mais carregando para sempre

