### PR TITLE
fix: Trata agendamentos sem assunto

### DIFF
--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -8,7 +8,7 @@ import {
 
 type Props = {
   email: string;
-  topic: string;
+  topic?: string;
   description: string;
   linkedin?: string;
   whatsapp?: string;

--- a/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   end: Date;
   description: string;
   isMonitor: boolean;
-  topic: string;
+  topic?: string;
   handleAccept(): void;
   handleClose(): void;
   handleRefuse(): void;

--- a/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
@@ -70,7 +70,7 @@ const ScheduleDetailsModal = ({
       )}
       {modalType === ScheduleDetailsModalType.CONFIRMED ? (
         <ConfirmedScheduleModalContent
-          topic={schedule.ScheduleTopics.name}
+          topic={schedule.ScheduleTopics?.name}
           email={userData.email}
           description={schedule.description}
           linkedin={userData.linkedin}
@@ -91,7 +91,7 @@ const ScheduleDetailsModal = ({
           start={schedule.start}
           end={schedule.end}
           isMonitor={schedule.is_monitoring}
-          topic={schedule.ScheduleTopics.name}
+          topic={schedule.ScheduleTopics?.name}
           handleAccept={handleAccept}
           handleClose={handleClose}
           handleRefuse={handleRefuse}

--- a/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleDetailsModal/index.tsx
@@ -20,7 +20,7 @@ const ScheduleDetailsModal = ({ schedule, isOpen, handleClose }: Props) => {
         student={`${schedule.student.enrollment} - ${schedule.student.name}`}
         course={schedule.subject.course.name}
         subject={schedule.subject.name}
-        topic={schedule.topic.name}
+        topic={schedule.topic?.name}
         description={schedule.description}
         monitor={`${schedule.monitor.enrollment} - ${schedule.monitor.name}`}
         professor={schedule.responsibleProfessor.name}

--- a/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
+++ b/src/screens/schedulesHistoric/components/ScheduleHistoricModalContent/index.tsx
@@ -10,7 +10,7 @@ type Props = {
   student: string;
   course: string;
   subject: string;
-  topic: string;
+  topic?: string;
   description: string;
   monitor: string;
   professor: string;

--- a/src/service/requests/useGetSchedulesHistoricRequest/types.ts
+++ b/src/service/requests/useGetSchedulesHistoricRequest/types.ts
@@ -47,7 +47,7 @@ export type TSchedules = {
   student: TStudent;
   responsibleProfessor: TResponsibleProfessor;
   subject: TSubject;
-  topic: TScheduleTopic;
+  topic?: TScheduleTopic;
   description: string;
 };
 

--- a/src/service/requests/useGetSchedulesRequest/types.ts
+++ b/src/service/requests/useGetSchedulesRequest/types.ts
@@ -47,8 +47,8 @@ export type TSchedules = {
   monitor: TMonitor;
   student: TStudent;
   is_monitoring: boolean;
-  schedule_topic_id: number;
-  ScheduleTopics: TScheduleTopic;
+  schedule_topic_id?: number;
+  ScheduleTopics?: TScheduleTopic;
 };
 
 export type TScheduleTopic = {


### PR DESCRIPTION
# Descrição

Conserta bug de tela branca ao abrir detalhes de um agendamento sem assunto.

# Em casos de bugfix

- Qual foi a causa do bug?
  - Quando um assunto não existe o objeto topic é undefined e estávamos tentando acessar o campo `name` dele, o que gera um erro.
- O que foi feito para corrigi-lo?
  - Trata assunto sendo opcional.
