### PR TITLE
fix: Guarda busca de disciplina na url

### DIFF
--- a/src/screens/resetPassword/hooks/index.ts
+++ b/src/screens/resetPassword/hooks/index.ts
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useState, useEffect, useMemo } from 'react';
 import jwt from 'jwt-decode';
 import { TResetPasswordToken } from './types';
@@ -9,11 +9,7 @@ import {
 } from '../../../utils/validateFields';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import { SCREENS } from '../../../utils/screens';
-
-const useQuery = () => {
-  const { search } = useLocation();
-  return useMemo(() => new URLSearchParams(search), [search]);
-};
+import useQuery from '../../../utils/useQuery';
 
 const useResetPassword = () => {
   const query = useQuery();

--- a/src/screens/subjects/index.tsx
+++ b/src/screens/subjects/index.tsx
@@ -19,6 +19,8 @@ const Subjects = () => {
     isLoadingSubjects,
     searchFieldElement,
     userTypeId,
+    search,
+    handleSearchChange,
     handleChangePage,
     handleSearch,
     handleSubjectClick,
@@ -149,6 +151,8 @@ const Subjects = () => {
             inputRef={searchFieldElement}
             placeholder="Buscar disciplina"
             handleSearch={handleSearch}
+            search={search}
+            handleSearchChange={handleSearchChange}
           />
 
           <SubjectsList

--- a/src/utils/useQuery.ts
+++ b/src/utils/useQuery.ts
@@ -1,0 +1,9 @@
+import { useLocation } from 'react-router-dom';
+import { useMemo } from 'react';
+
+const useQuery = () => {
+  const { search } = useLocation();
+  return useMemo(() => new URLSearchParams(search), [search]);
+};
+
+export default useQuery;


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Armazena a chave de busca de uma disciplina na url por meio de um queryParam, assim possibilitando retornar ao estado da busca ao retornar da tela de detalhes de uma disciplina para a tela de busca.

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acesse a tela de disciplinas
- [ ] Faça uma busca por uma disciplina
- [ ] Clique no card de uma disciplina para acessar seus detalhes
- [ ] Retorne no navegador
- [ ] Verifique se a chave de busca utilizada está presente na barra de busca e a busca foi realizada
