### PR TITLE
fix: Permite gerenciar disponibilidade em subjects

### DIFF
--- a/src/screens/subjectDetails/components/subjectHeader/index.tsx
+++ b/src/screens/subjectDetails/components/subjectHeader/index.tsx
@@ -10,6 +10,7 @@ import { TypeUserEnum } from '../../../../utils/constants';
 import { Container } from './styles';
 import MonitorAvailabilityModal from '../../../../components/monitorAvailabilityModal';
 import EditProfessorsModal from '../../../../components/editProfessorsModal';
+import { ManageHistoryRounded } from '@mui/icons-material';
 
 type Props = {
   subject?: TCompleteSubject;
@@ -78,6 +79,7 @@ const SubjectHeader = ({
       } else {
         return (
           <Button
+            startIcon={<ManageHistoryRounded />}
             onClick={() => monitorAvailabilityModal.handleOpenModal()}
             color="secondary"
             width="auto"

--- a/src/screens/subjects/components/SubjectsList/index.tsx
+++ b/src/screens/subjects/components/SubjectsList/index.tsx
@@ -1,5 +1,5 @@
 import { CircularProgress, Pagination } from '@mui/material';
-import { TSubject } from '../../../../service/requests/useListSubjectsRequest/types';
+import { TCompleteSubject as TSubject } from '../../../../service/requests/useGetSubject/types';
 import SubjectsListItem from '../SubjectsListItem';
 import {
   Container,

--- a/src/screens/subjects/components/SubjectsListItem/index.tsx
+++ b/src/screens/subjects/components/SubjectsListItem/index.tsx
@@ -1,8 +1,14 @@
-import { CalendarMonthRounded, EditRounded } from '@mui/icons-material';
 import { CardContent } from '@mui/material';
 import React from 'react';
 import { TSubject } from '../../../../service/requests/useListSubjectsRequest/types';
 import { TypeUserEnum } from '../../../../utils/constants';
+import { TCompleteSubject } from '../../../../service/requests/useGetSubject/types';
+import useGetLoggedUser from '../../../../service/storage/getLoggedUser';
+import {
+  CalendarMonthRounded,
+  EditRounded,
+  ManageHistoryRounded,
+} from '@mui/icons-material';
 import {
   ActionButton,
   ButtonContainer,
@@ -10,9 +16,11 @@ import {
   StyledCard,
   SubjectName,
 } from './styles';
+import MonitorAvailabilityModal from '../../../../components/monitorAvailabilityModal';
+import useMonitorAvailabilityModal from '../../../../components/monitorAvailabilityModal/hooks/useMonitorAvailabilityModal';
 
 type Props = {
-  subject: TSubject;
+  subject: TCompleteSubject;
   userTypeId?: number;
   handleAssignProfessors(subject: TSubject): void;
   handleConfirmSchedule(subject: TSubject): void;
@@ -26,14 +34,34 @@ const SubjectsListItem = ({
   handleConfirmSchedule,
   handleSubjectClick,
 }: Props) => {
+  const userId = useGetLoggedUser()?.sub;
+  const monitorAvailabilityModal = useMonitorAvailabilityModal();
   const renderButton = () => {
     if (userTypeId === TypeUserEnum.STUDENT) {
+      if (!!subject.monitors.length) {
+        if (subject.monitors.find((monitor) => monitor.studentId === userId)) {
+          return (
+            <ButtonContainer>
+              <ActionButton
+                onClick={monitorAvailabilityModal.handleOpenModal}
+                startIcon={<ManageHistoryRounded />}
+                wid="140px"
+                color="secondary"
+              >
+                Gerenciar
+              </ActionButton>
+            </ButtonContainer>
+          );
+        }
+      }
+
       return (
         <ButtonContainer>
           <ActionButton
             onClick={() => handleConfirmSchedule(subject)}
             startIcon={<CalendarMonthRounded />}
             wid="140px"
+            color="primary"
           >
             Agendar
           </ActionButton>
@@ -70,15 +98,21 @@ const SubjectsListItem = ({
   };
 
   return (
-    <StyledCard onClick={handleCardClick}>
-      <Container>
-        <CardContent>
-          <SubjectName>{subject.name}</SubjectName>
-        </CardContent>
+    <>
+      <MonitorAvailabilityModal
+        subject={subject}
+        {...monitorAvailabilityModal}
+      ></MonitorAvailabilityModal>
+      <StyledCard onClick={handleCardClick}>
+        <Container>
+          <CardContent>
+            <SubjectName>{subject.name}</SubjectName>
+          </CardContent>
 
-        {renderButton()}
-      </Container>
-    </StyledCard>
+          {renderButton()}
+        </Container>
+      </StyledCard>
+    </>
   );
 };
 

--- a/src/screens/subjects/components/SubjectsListItem/styles.ts
+++ b/src/screens/subjects/components/SubjectsListItem/styles.ts
@@ -6,6 +6,7 @@ import theme from '../../../../utils/theme';
 
 type Props = {
   wid: string;
+  color: string;
 };
 
 export const StyledCard = styled(Card).attrs({
@@ -38,13 +39,16 @@ export const Container = styled(Box).attrs({
   }
 `;
 
-export const ActionButton = styled(Button).attrs(({ wid }: Props) => ({
-  color: 'primary',
+export const ActionButton = styled(Button).attrs(({ wid, color }: Props) => ({
+  color: color,
   variant: 'outlined',
   width: wid,
 }))<Props>`
   :hover {
-    background-color: ${theme.palette.primary.main} !important;
+    background-color: ${(props) =>
+      props.color === 'primary'
+        ? theme.palette.primary.main
+        : theme.palette.secondary.main} !important;
     color: white;
   }
 

--- a/src/service/requests/useListSubjectsRequest/index.tsx
+++ b/src/service/requests/useListSubjectsRequest/index.tsx
@@ -32,6 +32,7 @@ const useListSubjectsRequest = () => {
         monitors: subject.Monitor.map((monitor) => ({
           ...monitor.student.user,
           id: monitor.id,
+          studentId: monitor.student.user.id,
           course: monitor.student.course,
           responsable: monitor.responsible_professor.user,
         })),


### PR DESCRIPTION
# Descrição

- Implementa um botão para ser possível gerenciar a disponibilidade das disciplinas em que o usuário é monitor sem precisar ir diretamente à página da disciplina.  

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário**

- [ ] Acessar uma conta que seja monitor de uma disciplina
- [ ] Buscar por essa disciplina na tela `/subjects`
- [ ] Verificar se o botão de gerenciar está presente no card 
- [ ] Efetuar a ação de gerenciar disponibilidade
