### PR TITLE
fix: Corrige botão gerenciar para monitor aprovado

### DIFF
--- a/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
+++ b/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
@@ -10,6 +10,7 @@ import {
 import useScheduleRequest from '../../../service/requests/useScheduleRequest';
 import { useSnackBar } from '../../../utils/renderSnackBar';
 import useTopics from './useTopics';
+import { TypeMonitoringStatus } from '../../../utils/constants';
 
 const useScheduleHelpModal = () => {
   const { showErrorSnackBar } = useSnackBar();
@@ -58,7 +59,9 @@ const useScheduleHelpModal = () => {
     if (!selectedSubject || selectedProfessorId === -1) return [];
 
     return selectedSubject.monitors.filter(
-      (monitor) => monitor.responsable.id === selectedProfessorId
+      (monitor) =>
+        monitor.responsable.id === selectedProfessorId &&
+        monitor.status === TypeMonitoringStatus.AVAILABLE
     );
   }, [selectedProfessorId, selectedSubject]);
 

--- a/src/screens/schedules/components/CancelScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/CancelScheduleModalContent/index.tsx
@@ -43,7 +43,7 @@ const CancelScheduleModalContent = ({
           hoverBorderColor="#2D2D2C29"
           onClick={handleCloseCancelModal}
         >
-          Não, desejo sair
+          Cancelar
         </ActionButton>
         <ActionButton
           color="error"
@@ -51,7 +51,7 @@ const CancelScheduleModalContent = ({
           hoverBackGroundColor="#F55858"
           onClick={handleCancelSchedule}
         >
-          Sim, continuar
+          Desmarcar
         </ActionButton>
       </ButtonsContainer>
     </>

--- a/src/service/requests/useListSubjectsRequest/index.tsx
+++ b/src/service/requests/useListSubjectsRequest/index.tsx
@@ -31,6 +31,7 @@ const useListSubjectsRequest = () => {
         responsables: subject.SubjectResponsability,
         monitors: subject.Monitor.map((monitor) => ({
           ...monitor.student.user,
+          status: monitor.status.status,
           id: monitor.id,
           studentId: monitor.student.user.id,
           course: monitor.student.course,

--- a/src/service/requests/useListSubjectsRequest/types.ts
+++ b/src/service/requests/useListSubjectsRequest/types.ts
@@ -1,4 +1,7 @@
-import { ReponsabilityProfessorStatus } from '../../../utils/constants';
+import {
+  ReponsabilityProfessorStatus,
+  TypeMonitoringStatus,
+} from '../../../utils/constants';
 import { TCompleteSubject } from '../useGetSubject/types';
 
 export type TSubject = {
@@ -52,6 +55,10 @@ export type TListSubjectsHttpResponse = {
           name: string;
           email: string;
         };
+      };
+      status: {
+        id: number;
+        status: TypeMonitoringStatus;
       };
       student: {
         user: {


### PR DESCRIPTION
# Descrição

- Corrigir um bug onde o botão de gerenciar disponibilidade na tela `/subjects` não aparecia pra monitores recém aprovados.
- Altera o texto dos botões na modal de desmarcar agendamento

# Em casos de bugfix

- A rota responsável na tela `/subjects` retornava apenas monitores com status disponível
- Para a correção a rota agora retorna todos os monitores 
- Um ajuste no modal de ajuda fui feito para impedir que monitores não disponíveis aparecessem na lista  de monitores disponíveis, por meio de uma alteração na tipagem da função e adição de um filtro adicional 

# Setup

- [ ] `yarn start`
- [ ] Possuir uma conta de monitor recém aprovado

# Cenários

## 1. Monitor recém aprovado

- [ ] Buscar pela disciplina em que o usuário é monitor
- [ ] Verificar se o botão de gerenciar aparece
- [ ] Gerenciar sua disponibilidade

## 2. Monitor não disponível

- [ ] Buscar pela disciplina em que o monitor recém aprovado é monitor
- [ ] Clicar no botão Agendar
- [ ] Verificar se os monitores sem horário cadastrado aparecem na lista de monitores
