### PR TITLE
Fix edit profile password and empty

### DIFF
--- a/src/screens/editProfile/components/accountSection/index.tsx
+++ b/src/screens/editProfile/components/accountSection/index.tsx
@@ -33,11 +33,15 @@ type Props = {
   course: string;
   isEditModeDisabled: boolean;
   showPassword: boolean;
+  showNewPassword: boolean;
+  showConfirmNewPassword: boolean;
   courses: TCourseData[];
   enrollmentError: string;
   nameError: string;
   passwordError: string;
   handleClickShowPassword(): void;
+  handleClickShowNewPassword(): void;
+  handleClickShowConfirmNewPassword(): void;
   handleMouseDownPassword(e: MouseEvent<HTMLButtonElement>): void;
   handleCourseChange(e: SelectChangeEvent<unknown>): void;
 };
@@ -54,11 +58,15 @@ const AccountSection = ({
   enrollmentRef,
   isEditModeDisabled,
   showPassword,
+  showNewPassword,
+  showConfirmNewPassword,
   courses,
   nameError,
   enrollmentError,
   passwordError,
   handleClickShowPassword,
+  handleClickShowNewPassword,
+  handleClickShowConfirmNewPassword,
   handleMouseDownPassword,
   handleCourseChange,
 }: Props) => (
@@ -125,18 +133,18 @@ const AccountSection = ({
           <>
             <Box>
               <StyledTextField
-                type={showPassword ? 'text' : 'password'}
+                type={showNewPassword ? 'text' : 'password'}
                 inputRef={newPasswordRef}
                 error={!!passwordError}
                 placeholder={'Nova senha'}
                 endAdornment={
                   <InputAdornment position="end">
                     <IconButton
-                      onClick={handleClickShowPassword}
+                      onClick={handleClickShowNewPassword}
                       onMouseDown={handleMouseDownPassword}
                       edge="end"
                     >
-                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                      {showNewPassword ? <VisibilityOff /> : <Visibility />}
                     </IconButton>
                   </InputAdornment>
                 }
@@ -147,18 +155,22 @@ const AccountSection = ({
             </Box>
             <Box>
               <StyledTextField
-                type={showPassword ? 'text' : 'password'}
+                type={showConfirmNewPassword ? 'text' : 'password'}
                 inputRef={confirmNewPasswordRef}
                 error={!!passwordError}
                 placeholder={'Confirmar senha'}
                 endAdornment={
                   <InputAdornment position="end">
                     <IconButton
-                      onClick={handleClickShowPassword}
+                      onClick={handleClickShowConfirmNewPassword}
                       onMouseDown={handleMouseDownPassword}
                       edge="end"
                     >
-                      {showPassword ? <VisibilityOff /> : <Visibility />}
+                      {showConfirmNewPassword ? (
+                        <VisibilityOff />
+                      ) : (
+                        <Visibility />
+                      )}
                     </IconButton>
                   </InputAdornment>
                 }

--- a/src/screens/editProfile/hooks/useEditProfile.ts
+++ b/src/screens/editProfile/hooks/useEditProfile.ts
@@ -143,11 +143,11 @@ const useEditProfile = () => {
       const user: TUpdateUserRequestBody = {
         name: nameRef.current?.value || '',
         enrollment: enrollmentRef.current?.value || '',
+        description: descriptionRef.current?.value || '',
+        whatsapp: whatsappRef.current?.value,
+        linkedin: linkedinRef.current?.value,
+        contactEmail: contactEmailRef.current?.value,
       };
-
-      if (contactEmailRef.current?.value) {
-        user.contactEmail = contactEmailRef.current?.value;
-      }
 
       if (newPasswordRef.current?.value)
         user.password = newPasswordRef.current?.value;
@@ -155,19 +155,10 @@ const useEditProfile = () => {
       if (passwordRef.current?.value)
         user.oldPassword = passwordRef.current?.value;
 
-      if (descriptionRef.current?.value)
-        user.description = descriptionRef.current?.value;
-
       const courseId = courses.find((crs) => crs.name === course)?.id;
       if (userInfo?.course.id !== courseId) {
         user.courseId = courseId;
       }
-
-      if (whatsappRef.current?.value)
-        user.whatsapp = whatsappRef.current?.value;
-
-      if (linkedinRef.current?.value)
-        user.linkedin = linkedinRef.current?.value;
 
       void updateUser(user);
     }

--- a/src/screens/editProfile/hooks/useEditProfile.ts
+++ b/src/screens/editProfile/hooks/useEditProfile.ts
@@ -58,6 +58,8 @@ const useEditProfile = () => {
   const [course, setCourse] = useState<string>('');
   const [isEditModeDisabled, setIsEditModeDisabled] = useState(true);
   const [showPassword, setShowPassword] = useState(false);
+  const [showNewPassword, setShowNewPassword] = useState(false);
+  const [showConfirmNewPassword, setShowConfirmNewPassword] = useState(false);
 
   const [nameError, setNameError] = useState('');
   const [contactEmailError, setContactEmailError] = useState('');
@@ -176,9 +178,10 @@ const useEditProfile = () => {
     event.preventDefault();
   };
 
-  const handleClickShowPassword = () => {
-    setShowPassword(!showPassword);
-  };
+  const handleClickShowPassword = () => setShowPassword(!showPassword);
+  const handleClickShowNewPassword = () => setShowNewPassword(!showNewPassword);
+  const handleClickShowConfirmNewPassword = () =>
+    setShowConfirmNewPassword(!showConfirmNewPassword);
 
   const handleCancelClick = () => {
     setIsEditModeDisabled(true);
@@ -298,6 +301,8 @@ const useEditProfile = () => {
     linkedinRef,
     whatsappRef,
     showPassword,
+    showNewPassword,
+    showConfirmNewPassword,
     course,
     courses,
     contactEmailError,
@@ -313,6 +318,8 @@ const useEditProfile = () => {
     handleCancelClick,
     handleCourseChange,
     handleClickShowPassword,
+    handleClickShowNewPassword,
+    handleClickShowConfirmNewPassword,
     handleMouseDownPassword,
     handleSaveClick,
   };

--- a/src/screens/editProfile/index.tsx
+++ b/src/screens/editProfile/index.tsx
@@ -38,6 +38,8 @@ const EditProfile = () => {
     isEditModeDisabled,
     editProfileTitle,
     showPassword,
+    showNewPassword,
+    showConfirmNewPassword,
     courses,
     contactEmailError,
     enrollmentError,
@@ -45,6 +47,8 @@ const EditProfile = () => {
     passwordError,
     handleSaveClick,
     handleClickShowPassword,
+    handleClickShowNewPassword,
+    handleClickShowConfirmNewPassword,
     handleMouseDownPassword,
     handleEditProfileClick,
     handleCancelClick,
@@ -75,11 +79,15 @@ const EditProfile = () => {
           confirmNewPasswordRef={confirmNewPasswordRef}
           isEditModeDisabled={isEditModeDisabled}
           showPassword={showPassword}
+          showNewPassword={showNewPassword}
+          showConfirmNewPassword={showConfirmNewPassword}
           enrollmentError={enrollmentError}
           nameError={nameError}
           passwordError={passwordError}
           handleCourseChange={handleCourseChange}
           handleClickShowPassword={handleClickShowPassword}
+          handleClickShowNewPassword={handleClickShowNewPassword}
+          handleClickShowConfirmNewPassword={handleClickShowConfirmNewPassword}
           handleMouseDownPassword={handleMouseDownPassword}
         />
 


### PR DESCRIPTION
# Descrição

Corrige erros levantados pelo time de teste:
- Quando tento salvar um linkedin, descrição ou wpp vazio o campo não é alterado
- Os botões de visibilidade estão mostrando todos os campos, não funcionando individualmente
