### PR TITLE
fix: Conserta regex do linkedin

### DIFF
--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -90,7 +90,7 @@ export const validateEnrollment = (enrollment: string): string => {
 
 export const validateLinkedin = (linkedin: string): string => {
   const re =
-    /^(https:(?:\/\/)www.linkedin.com(\/)in(\/)([\w.#&-]{5,60}))(\/)$/gm;
+    /^(http(s)?:\/\/)?([\w]+\.)?linkedin\.com\/(pub|in|profile)\/([-a-zA-Z0-9]+)\/*/gm;
 
   if (!linkedin) return '';
 


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Corrigir regex do linkedin](https://computero.atlassian.net/browse/DS-220)


<!-- O que este pull request faz? -->
Corrige regex de validação do linkedin

### 🐞 Em casos de bugfix

- Qual foi a causa do bug?
  - A regex antiga não aceitava link sem `https` e outras coisas simples
- O que foi feito para corrigi-lo?
  - Usa reges do site https://www.debugpointer.com/regex/regex-for-linkedin-profile-url

# Setup

- [ ] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Editar linkedin

- [ ] Entre na tela de cadastro de aluno
- [ ] Tente colocar diferentes URLs válidas de linkedin e verifique que não deu erro
- [ ] Faça login com uma conta de aluno
- [ ] Tente alterar o linkedin para diversos formatos válidos e verifique que não deu erro
