### PR TITLE
fix: Subject code added in the subjects listing

### DIFF
--- a/src/screens/subjects/components/SubjectsListItem/index.tsx
+++ b/src/screens/subjects/components/SubjectsListItem/index.tsx
@@ -106,7 +106,9 @@ const SubjectsListItem = ({
       <StyledCard onClick={handleCardClick}>
         <Container>
           <CardContent>
-            <SubjectName>{subject.name}</SubjectName>
+            <SubjectName>
+              {subject.code} - {subject.name}
+            </SubjectName>
           </CardContent>
 
           {renderButton()}


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Inclue o código da disciplina junto ao nome na página que lista as disciplinas.


# Setup

- [ ] Precisa rodar build?
- [x] Precisa subir o backend?
- [ ] Precisa adicionar, remover ou editar algum registro no banco de dados?

# Cenários

Em alguns casos, disciplinas com o mesmo nome têm códigos diferentes. No cenário proposto, o usuário deve conseguir, além do nome da disciplina, visualizar o código da disciplina. Na versão anterior a esse PR, o usuário só consegue visualizar o nome da disciplina e não consegue distinguir disciplinas com códigos diferentes.




