### PR TITLE
feat: Adiciona hint de local de preferência

### DIFF
--- a/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/ConfirmedScheduleModalContent/index.tsx
@@ -5,6 +5,8 @@ import {
   DataContainer,
   Label,
 } from '../ScheduleDetailsModal/styles';
+import PreferentialPlaceAlert from '../PreferentialPlaceAlert';
+import { TPreferentialPlaceProperties } from '../../hooks/types';
 
 type Props = {
   email: string;
@@ -15,6 +17,7 @@ type Props = {
   isMonitor: boolean;
   handleClose(): void;
   handleOpenCancelModal(): void;
+  preferentialPlaceProperties?: TPreferentialPlaceProperties;
 };
 
 const ConfirmedScheduleModalContent = ({
@@ -26,6 +29,7 @@ const ConfirmedScheduleModalContent = ({
   isMonitor,
   handleClose,
   handleOpenCancelModal,
+  preferentialPlaceProperties,
 }: Props) => (
   <>
     <Typography variant="h4">Horário agendado</Typography>
@@ -33,6 +37,12 @@ const ConfirmedScheduleModalContent = ({
       Entre em contato com o(a) {isMonitor ? 'aluno' : 'monitor'}
       (a) para definirem a plataforma onde será feita a ajuda.
     </Typography>
+
+    <PreferentialPlaceAlert
+      isWarning={preferentialPlaceProperties?.isWarning}
+      message={preferentialPlaceProperties?.message}
+      preferentialPlace={preferentialPlaceProperties?.preferentialPlace}
+    />
 
     <DataContainer>
       <Label>Assunto</Label>

--- a/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
+++ b/src/screens/schedules/components/PendingScheduleModalContent/index.tsx
@@ -7,6 +7,8 @@ import {
   Label,
 } from '../ScheduleDetailsModal/styles';
 import { ChangeStatusButton } from './styles';
+import PreferentialPlaceAlert from '../PreferentialPlaceAlert';
+import { TPreferentialPlaceProperties } from '../../hooks/types';
 
 type Props = {
   name: string;
@@ -20,6 +22,7 @@ type Props = {
   handleAccept(): void;
   handleClose(): void;
   handleRefuse(): void;
+  preferentialPlaceProperties?: TPreferentialPlaceProperties;
 };
 
 const PendingScheduleModalContent = ({
@@ -34,6 +37,7 @@ const PendingScheduleModalContent = ({
   handleAccept,
   handleClose,
   handleRefuse,
+  preferentialPlaceProperties,
 }: Props) => (
   <>
     <Typography variant="h4">Requisição de agendamento</Typography>
@@ -42,6 +46,12 @@ const PendingScheduleModalContent = ({
         ? 'Este agendamento encontra-se no status "Pendente". Ao aceitá-lo, o(a) aluno(a) receberá um e-mail informando que o agendamento está confirmado.'
         : 'Este agendamento encontra-se no status "Aguardando confirmação". Quando o(a) monitor(a) aceitá-lo você receberá um e-mail informando que o agendamento está confirmado.'}
     </Typography>
+
+    <PreferentialPlaceAlert
+      isWarning={preferentialPlaceProperties?.isWarning}
+      message={preferentialPlaceProperties?.message}
+      preferentialPlace={preferentialPlaceProperties?.preferentialPlace}
+    />
 
     <DataContainer>
       <Label>{isMonitor ? 'Aluno' : 'Monitor'}(a)</Label>

--- a/src/screens/schedules/components/PreferentialPlaceAlert/index.tsx
+++ b/src/screens/schedules/components/PreferentialPlaceAlert/index.tsx
@@ -1,0 +1,14 @@
+import { Alert } from '@mui/material';
+import { TPreferentialPlaceProperties } from '../../hooks/types';
+
+const PreferentialPlaceAlert = ({
+  isWarning,
+  message,
+  preferentialPlace,
+}: TPreferentialPlaceProperties) => (
+  <Alert severity={isWarning ? 'warning' : 'success'}>
+    {message} <strong>{preferentialPlace}</strong>
+  </Alert>
+);
+
+export default PreferentialPlaceAlert;

--- a/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
+++ b/src/screens/schedules/components/ScheduleDetailsModal/index.tsx
@@ -3,7 +3,10 @@ import { useMemo } from 'react';
 import LoadingAnimation from '../../../../components/loadingAnimation';
 import Modal from '../../../../components/modal';
 import { TSchedules } from '../../../../service/requests/useGetSchedulesRequest/types';
-import { ScheduleDetailsModalType } from '../../hooks/types';
+import {
+  ScheduleDetailsModalType,
+  TPreferentialPlaceProperties,
+} from '../../hooks/types';
 import CancelScheduleModalContent from '../CancelScheduleModalContent';
 import ConfirmedScheduleModalContent from '../ConfirmedScheduleModalContent';
 import PendingScheduleModalContent from '../PendingScheduleModalContent';
@@ -20,6 +23,7 @@ type Props = {
   handleCancelSchedule(): void;
   handleClose(): void;
   handleRefuse(): void;
+  preferentialPlaceProperties?: TPreferentialPlaceProperties;
 };
 
 const ScheduleDetailsModal = ({
@@ -33,6 +37,7 @@ const ScheduleDetailsModal = ({
   handleAccept,
   handleClose,
   handleRefuse,
+  preferentialPlaceProperties,
 }: Props) => {
   if (!schedule || modalType === ScheduleDetailsModalType.DEFAULT) return <></>;
 
@@ -76,6 +81,7 @@ const ScheduleDetailsModal = ({
           linkedin={userData.linkedin}
           whatsapp={userData.whatsapp}
           isMonitor={schedule.is_monitoring}
+          preferentialPlaceProperties={preferentialPlaceProperties}
           handleClose={handleClose}
           handleOpenCancelModal={handleOpenCancelModal}
         />
@@ -92,6 +98,7 @@ const ScheduleDetailsModal = ({
           end={schedule.end}
           isMonitor={schedule.is_monitoring}
           topic={schedule.ScheduleTopics?.name}
+          preferentialPlaceProperties={preferentialPlaceProperties}
           handleAccept={handleAccept}
           handleClose={handleClose}
           handleRefuse={handleRefuse}

--- a/src/screens/schedules/hooks/types.ts
+++ b/src/screens/schedules/hooks/types.ts
@@ -1,5 +1,11 @@
 import { TSchedules } from '../../../service/requests/useGetSchedulesRequest/types';
 
+export type TPreferentialPlaceProperties = {
+  isWarning?: boolean;
+  message?: string;
+  preferentialPlace?: string;
+};
+
 export type TFormatedSchedules = {
   month: string;
   day: number;

--- a/src/screens/schedules/hooks/useSchedules.ts
+++ b/src/screens/schedules/hooks/useSchedules.ts
@@ -5,6 +5,7 @@ import { useSnackBar } from '../../../utils/renderSnackBar';
 import useScheduleDetailsModal from './useScheduleDetailsModal';
 import useFilterParams from './useFilterParams';
 import useFormatSchedules from './useFormatSchedules';
+import { TPreferentialPlaceProperties } from './types';
 
 const useSchedules = () => {
   const { showErrorSnackBar } = useSnackBar();
@@ -23,6 +24,33 @@ const useSchedules = () => {
     handleCancelSchedule,
     isCancelSuccess,
   } = useScheduleDetailsModal();
+
+  const preferentialPlaceProperties = useMemo(() => {
+    const properties: TPreferentialPlaceProperties = {
+      isWarning: false,
+      message: '',
+      preferentialPlace: selectedSchedule?.monitor_settings?.preferential_place,
+    };
+
+    if (!selectedSchedule) return undefined;
+
+    if (selectedSchedule.is_monitoring) {
+      if (
+        selectedSchedule.monitor.MonitorSettings[0].preferential_place !==
+        selectedSchedule.monitor_settings?.preferential_place
+      ) {
+        properties.isWarning = true;
+        properties.message =
+          'Quando o agendamento foi requisitado, seu local de preferência era: ';
+      } else {
+        properties.message = 'Seu local de preferência de atendimento é em: ';
+      }
+    } else {
+      properties.message = 'Este(a) monitor(a) costuma atender em: ';
+    }
+
+    return properties;
+  }, [selectedSchedule]);
 
   const [page, setPage] = useState(1);
   const [selectedFilter, setSelectedFilter] = useState(
@@ -90,6 +118,7 @@ const useSchedules = () => {
     handleCloseCancelModal,
     handleOpenCancelModal,
     handleCancelSchedule,
+    preferentialPlaceProperties,
   };
 };
 

--- a/src/screens/schedules/index.tsx
+++ b/src/screens/schedules/index.tsx
@@ -33,6 +33,7 @@ const Schedules = () => {
     handleRefuseSchedule,
     totalPages,
     handleCloseScheduleDetailsModal,
+    preferentialPlaceProperties,
   } = useSchedules();
 
   const renderFilterChips = () => {
@@ -54,6 +55,7 @@ const Schedules = () => {
         schedule={selectedSchedule}
         isOpen={isScheduleDetailsModalOpen}
         isCancelSuccess={isCancelSuccess}
+        preferentialPlaceProperties={preferentialPlaceProperties}
         handleOpenCancelModal={handleOpenCancelModal}
         handleCloseCancelModal={handleCloseCancelModal}
         handleAccept={handleAcceptSchedule}

--- a/src/service/requests/useGetSchedulesRequest/types.ts
+++ b/src/service/requests/useGetSchedulesRequest/types.ts
@@ -1,6 +1,12 @@
 import { SchedulesStatus } from '../../../utils/constants';
 import { TUser } from '../useGetAllMonitorRequests/types';
 
+export type TMonitorSettings = {
+  id: number;
+  preferential_place: string;
+  is_active: boolean;
+};
+
 export type TCourse = {
   id: number;
   name: string;
@@ -34,6 +40,7 @@ export type TMonitor = {
   subject_id: number;
   student: TStudent;
   subject: TSubject;
+  MonitorSettings: TMonitorSettings[];
 };
 
 export type TSchedules = {
@@ -49,6 +56,8 @@ export type TSchedules = {
   is_monitoring: boolean;
   schedule_topic_id?: number;
   ScheduleTopics?: TScheduleTopic;
+  monitor_settings_id?: number;
+  monitor_settings?: TMonitorSettings;
 };
 
 export type TScheduleTopic = {


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Adiciona hint de local de preferência nas modais de agendamento confirmado e pendente

# Setup

- [ ] yarn start

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Logue como um aluno que tenha agendamentos ainda pra acontecer (e.g. marcos.aluno@icomp.ufam.edu.br/12345678)
- [ ] Vá na aba de agendamentos e clique nos agendamentos
- [ ] Verifique se o hint de local de preferência de cada atendimento é mostrado
- [ ] Deslogue da aplicação e entre como o monitor dos atendimentos que esse usuário solicitou (e.g. chris.aluno@icomp.ufam.edu.br/12345678)
- [ ] Vá na aba de agendamentos e clique nos agendamentos
- [ ] Verifique se o hint de local de preferência de cada atendimento é mostrado
- [ ] Mude o local de atendimento desse monitor
- [ ] Verifique nos agenmentos se o hint de warning foi exibido 
