### PR TITLE
fix: Aceita e-mails com hífen

### DIFF
--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -22,9 +22,9 @@ export const validateEmail = (email: string): string => {
   if (email.split('@')[0].length < 3 || email.split('@')[0].length > 20)
     return 'Informe um e-mail válido!';
 
-  const reIcomp = /^([\w.]{3,20})@icomp.ufam.edu.br$/gm;
-  const reSuper = /^([\w.]{3,20})@super.ufam.edu.br$/gm;
-  const reUfam = /^([\w.]{3,20})@ufam.edu.br$/gm;
+  const reIcomp = /^([\w.-]{3,20})@icomp.ufam.edu.br$/gm;
+  const reSuper = /^([\w.-]{3,20})@super.ufam.edu.br$/gm;
+  const reUfam = /^([\w.-]{3,20})@ufam.edu.br$/gm;
 
   if (!reIcomp.test(email) && !reSuper.test(email) && !reUfam.test(email))
     return 'Informe um e-mail válido!';


### PR DESCRIPTION
# Descrição

<!-- Coloque aqui o card que originou esta PR -->
[📌 Campo de e-mail não aceita hífen](https://computero.atlassian.net/browse/DS-229)

- Adiciona o hífen (-) como caractere aceito aos e-mail utilizados para cadastro.

### 🐞 Em casos de bugfix

- Qual foi a causa do bug? E-mails com hífen (-) não estavam sendo aceitos no formulário de cadastro.
- O que foi feito para corrigi-lo? O caractere hífen (-) foi adicionado ao regex de validação de e-mails.

# Setup

- [ ] Altere o .env para apontar para stg.
- [ ] `yarn start`

# Cenários

<!-- Detalhar os casos de teste e as condições de aceitação de cada um deles -->

## 1. Cenário A**

- [ ] Acesse a tela de cadastro de aluno
- [ ] Tente cadastrar um aluno com o email `aluno-teste@icomp.ufam.edu.br` e verifique que o erro de e-mail inválido não foi mostrado
- [ ] Acesse a tela de cadastro de professor
- [ ] Tente cadastrar um professor com o email `prof-teste@icomp.ufam.edu.br` e verifique que o erro de e-mail inválido não foi mostrado

