### PR TITLE
fix: Corrige a paginação na tela de disciplinas

### DIFF
--- a/src/screens/subjects/hooks/useSubjects.ts
+++ b/src/screens/subjects/hooks/useSubjects.ts
@@ -93,6 +93,12 @@ const useSubjects = () => {
       return;
     }
 
+    if (queryPage) {
+      void listSubjects({ page: Number(queryPage) });
+      setPage(Number(queryPage));
+
+      return;
+    }
     void listSubjects();
   }, []);
 


### PR DESCRIPTION
# Descrição

- Corrige um bug que estava fazendo com que a tela `/subjects` não recuperasse a última página visualizada.

# Em casos de bugfix

- O hook responsável pela tela `/subjects` não estava abordando a situação de retornar para a página que estava sendo visualizada em caso de retornar para a tela sem que tivesse usado a barra de busca.
- Adição de uma condição no hook para agir quando houver apenas o parâmetro `page` na query.

# Setup

- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acessar a tela `/subjects`
- [ ] Clicar para visualizar alguma página além da primeira
- [ ] Clicar no card de alguma disciplina
- [ ] Retorna para a tela `/subjects`, seja pelo navegador ou pela seta de retorno do sistema
- [ ] Verificar se a tela carrega as disciplinas da tela previamente vistas