### PR TITLE
fix: Corrige botão de editar monitoria

### DIFF
--- a/src/screens/subjectDetails/components/subjectHeader/index.tsx
+++ b/src/screens/subjectDetails/components/subjectHeader/index.tsx
@@ -121,14 +121,16 @@ const SubjectHeader = ({
               </>
             );
           } else {
-            <Button
-              startIcon={<ManageHistoryRounded />}
-              onClick={handleManageMonitoringClick}
-              color="secondary"
-              width="auto"
-            >
-              Gerenciar Disponibilidade
-            </Button>;
+            return (
+              <Button
+                startIcon={notMobile ? <ManageHistoryRounded /> : null}
+                onClick={handleManageMonitoringClick}
+                color="secondary"
+                width="auto"
+              >
+                {notMobile ? 'Editar Monitoria' : <ManageHistoryRounded />}
+              </Button>
+            );
           }
         } else {
           return (


### PR DESCRIPTION
# Descrição

- Corrige o problema que fazia o botão de editar monitoria não aparecer na tela de detalhes de disciplina

# Em casos de bugfix

- O bug foi causado pela ausência de um return na condicional responsável por apresentar o botão na tela
- O bug foi corrigido colocando o return no devido local 

# Setup

- [ ] yarn start

# Cenários

## 1. Cenário A**

- [ ] Logar conta de monitor 
- [ ] Acessar a tela de detalhes da disciplina em que é monitor
- [ ] Verificar se o botão de editar monitoria está presente
