### PR TITLE
fix: Perfil de Professor exibe disciplinas com formatação estranha

### DIFF
--- a/src/screens/subjects/components/SubjectsListItem/index.tsx
+++ b/src/screens/subjects/components/SubjectsListItem/index.tsx
@@ -84,7 +84,7 @@ const SubjectsListItem = ({
       );
     }
 
-    return <></>;
+    return <ButtonContainer></ButtonContainer>;
   };
 
   const handleCardClick = (e: React.MouseEvent) => {


### PR DESCRIPTION
# Descrição

<!-- O que este pull request faz? -->

- Corrigindo os cards de disciplina no perfil do professor.

# Em casos de bugfix

- Na tela de disciplinas, existiam condições para adicionar botões nos perfis de aluno e coordenador. Quando era um perfil diferente desses, uma div vazia era adicionada, resultando em um espaçamento estranho no final.
- Para corrigir isso, substituí a div vazia por um contêiner de botão, que padroniza a formatação para todos os tipos de perfil.

# Setup

- [ ] yarn start

