### PR TITLE
fix: Adiciona campo siape no cadastro de professor

### DIFF
--- a/src/screens/registerProfessor/components/FormRegister/index.tsx
+++ b/src/screens/registerProfessor/components/FormRegister/index.tsx
@@ -9,6 +9,7 @@ import {
   validateEmail,
   validateName,
   validatePassword,
+  validateSiape,
 } from '../../../../utils/validateFields';
 import {
   FormContainer,
@@ -38,6 +39,10 @@ const FormRegister = () => {
     emailError,
     handleEmailChange,
     setEmailError,
+    siape,
+    siapeError,
+    setSiapeError,
+    handleSiapeChange,
     password,
     passwordError,
     showPassword,
@@ -60,6 +65,13 @@ const FormRegister = () => {
 
   const NameError = () => {
     if (!!nameError) return <FormHelperText error>{nameError}</FormHelperText>;
+
+    return <></>;
+  };
+
+  const SiapeError = () => {
+    if (!!siapeError)
+      return <FormHelperText error>{siapeError}</FormHelperText>;
 
     return <></>;
   };
@@ -123,6 +135,18 @@ const FormRegister = () => {
                     onChange={handleEmailChange}
                   />
                   <EmailError />
+                </TextFieldContainer>
+                <TextFieldContainer>
+                  <StyledFormTextField
+                    value={siape}
+                    error={!!siapeError}
+                    id="siape"
+                    name="siape"
+                    placeholder="Matrícula Siape"
+                    onBlur={() => setSiapeError(validateSiape(siape))}
+                    onChange={handleSiapeChange}
+                  />
+                  <SiapeError />
                 </TextFieldContainer>
                 <TextFieldContainer>
                   <StyledFormTextField

--- a/src/screens/registerProfessor/components/hooks/types.ts
+++ b/src/screens/registerProfessor/components/hooks/types.ts
@@ -9,6 +9,11 @@ export type TRegisterProfessorHook = {
   handleEmailChange(e: React.ChangeEvent<HTMLInputElement>): void;
   setEmailError(email: string): void;
 
+  siape: string;
+  siapeError: string;
+  setSiapeError(siape: string): void;
+  handleSiapeChange(e: React.ChangeEvent<HTMLInputElement>): void;
+
   password: string;
   passwordError: string;
   showPassword: boolean;

--- a/src/screens/registerProfessor/components/hooks/useRegisterProfessor.ts
+++ b/src/screens/registerProfessor/components/hooks/useRegisterProfessor.ts
@@ -8,6 +8,7 @@ import {
   validateEmail,
   validateName,
   validatePassword,
+  validateSiape,
 } from '../../../../utils/validateFields';
 
 const useRegisterProfessor = () => {
@@ -25,6 +26,8 @@ const useRegisterProfessor = () => {
   const [confPassword, setConfPassword] = useState('');
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');
+  const [siape, setSiape] = useState('');
+  const [siapeError, setSiapeError] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
 
@@ -36,6 +39,9 @@ const useRegisterProfessor = () => {
   };
   const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
+  };
+  const handleSiapeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSiape(e.target.value);
   };
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setName(e.target.value);
@@ -71,6 +77,11 @@ const useRegisterProfessor = () => {
       setNameError(currentErrorName);
     }
 
+    const currentSiapeError = validateSiape(siape);
+    if (currentSiapeError) {
+      setSiapeError(currentSiapeError);
+    }
+
     const currentErrorEmail = validateEmail(email);
     if (currentErrorEmail) {
       setEmailError(currentErrorEmail);
@@ -93,9 +104,10 @@ const useRegisterProfessor = () => {
       !currentErrorName &&
       !currentErrorEmail &&
       !currentErrorPassword &&
-      !currentErrorConfirmPassword
+      !currentErrorConfirmPassword &&
+      !currentSiapeError
     ) {
-      void register(name, email, password, confPassword);
+      void register(name, email, siape, password, confPassword);
     }
   };
 
@@ -123,6 +135,7 @@ const useRegisterProfessor = () => {
   return {
     handleNameChange,
     handleEmailChange,
+    handleSiapeChange,
     handlePasswordChange,
     handleConfPasswordChange,
     handleCancelClick,
@@ -132,18 +145,21 @@ const useRegisterProfessor = () => {
     handleMouseDownPassword,
     name,
     email,
+    siape,
     password,
     confPassword,
     error,
     isLoading,
     isSuccess,
     nameError,
+    siapeError,
     emailError,
     passwordError,
     confPasswordError,
     showPassword,
     showConfirmPassword,
     setNameError,
+    setSiapeError,
     setEmailError,
     setPasswordError,
     setConfPasswordError,

--- a/src/service/requests/useRegisterProfessorRequest/index.ts
+++ b/src/service/requests/useRegisterProfessorRequest/index.ts
@@ -15,6 +15,7 @@ const useRegisterProfessorRequest = (): TRegisterProfessorRequestHook => {
   const register = async (
     name: string,
     email: string,
+    siape: string,
     password: string,
     confirmPassword: string
   ) => {
@@ -23,6 +24,7 @@ const useRegisterProfessorRequest = (): TRegisterProfessorRequestHook => {
     setError(undefined);
     const body: TRegisterProfessorRequest = {
       name,
+      siape,
       email,
       password,
       confirm_password: confirmPassword,

--- a/src/service/requests/useRegisterProfessorRequest/types.ts
+++ b/src/service/requests/useRegisterProfessorRequest/types.ts
@@ -5,6 +5,7 @@ export type TRegisterProfessorRequestHook = {
   register(
     name: string,
     email: string,
+    siape: string,
     password: string,
     confirm_password: string
   ): void;
@@ -12,6 +13,7 @@ export type TRegisterProfessorRequestHook = {
 
 export type TRegisterProfessorRequest = {
   name: string;
+  siape: string;
   email: string;
   password: string;
   confirm_password: string;

--- a/src/utils/validateFields.ts
+++ b/src/utils/validateFields.ts
@@ -11,6 +11,16 @@ export const validateName = (name: string): string => {
   return '';
 };
 
+export const validateSiape = (siape: string): string => {
+  if (!siape || siape.indexOf('') === -1) return 'Siape Inválido';
+
+  if (/\D/.test(siape)) return 'O Siape não pode conter letras!';
+
+  if (siape.length != 7) return 'O Siape tem que ter 7 caractéres!';
+
+  return '';
+};
+
 export const validateEmail = (email: string): string => {
   if (!email || email.indexOf('@') === -1) return 'E-mail inválido!';
 


### PR DESCRIPTION
# Descrição

- Arruma um bug que impossibilitava o usuário professor de realizar cadastro

# Em casos de bugfix

- O bug foi causado pela mudança da rota de cadastro de professor e o frontend não estar preparado para essa mudança
- Para corrigir o bug foi adicionado um campo de dado no cadastro para se adequar a rota

# Setup

- [ ] yarn start

# Cenários

## 1. Cenário A**

- [ ] Acesse a tela de cadastro de professor
- [ ] Faça um cadastro como professor

