### PR TITLE
fix: Resolve bug na tela de perfil do coordenador

### DIFF
--- a/src/screens/editProfile/hooks/useEditProfile.ts
+++ b/src/screens/editProfile/hooks/useEditProfile.ts
@@ -228,7 +228,9 @@ const useEditProfile = () => {
       if (confirmNewPasswordRef.current)
         confirmNewPasswordRef.current.value = '';
 
-      setCourse(userInfo.course.name);
+      if (isStudent) {
+        setCourse(userInfo.course.name);
+      }
 
       if (isOnEditMode) {
         handleEditProfileClick();


### PR DESCRIPTION
# Descrição

[📌 [FRONT] Sistema não exibe tela com informações de Professor e Coordenador](https://computero.atlassian.net/browse/DS-311)

- Corrige bug na tela de perfil de coordenador e professor

## 🐛  Qual foi a causa do bug?
O hook useEditProfile utilizava setCourse para preencher as informações na tela com as informações retornadas pelo backend, porém no caso de professores e coordenadores não possuem vinculo com um curso, então estava sendo passado undefined para a função que espera uma string.

## ✅  O que foi feito para corrigi-lo?
Foi adicionado um `if` para verificar se o usuário é um aluno. Apenas se o usuário for um aluno a função `setCourse` será chamada

# Setup

- [ ] Aponte para o backend de staging
- [ ] `yarn start`
- [ ] Faça login com a conta `coordenador@icomp.ufam.edu.br` | `12345678`

# Cenários

## 1. Cenário A**

- [ ] Clique no ícone para acessar a tela de perfil
- [ ] Verificar se a tela carrega normalmente da forma esperada

