### PR TITLE
fix: Conserta o calendário de disponibilidade

### DIFF
--- a/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
+++ b/src/components/ScheduleHelpModal/components/FormScheduleModalContent/index.tsx
@@ -136,7 +136,9 @@ const FormScheduleModalContent = ({
           )}
           loading={isLoadingMonitorAvailableTimes}
           shouldDisableDate={(day) =>
-            !monitorAvailableTimes?.find((time) => time.week_day === day.day())
+            !monitorAvailableTimes?.find(
+              (time) => time.week_day === day.isoWeekday() - 1
+            )
           }
         />
 

--- a/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
+++ b/src/components/ScheduleHelpModal/hooks/useScheduleHelpModal.ts
@@ -70,7 +70,7 @@ const useScheduleHelpModal = () => {
 
     const monitorAvailableTimes = monitor.availability;
     const availableDayTime = monitorAvailableTimes.find(
-      (time) => time.week_day === selectedDate.day()
+      (time) => time.week_day === selectedDate.isoWeekday() - 1
     );
     if (!availableDayTime) return [];
 


### PR DESCRIPTION
# Descrição

- Corrige um bug onde a disponibilidade do monitor não estava aparecendo corretamente na modal de agendamento.

## 🐛  Qual foi a causa do bug?
O padrão de dia da semana vindo do backend utiliza a segunda feira como dia 0, porém a lib utilizada no frontend atribui o dia 0 como o domingo, causando erros na exibição dos dados nos components.

## ✅  O que foi feito para corrigi-lo?
O formato da data utilizada pela lib foi alterado para o padrão `iso`, onde a segunda é atribuída com número 1 e domingo dia 7. Depois foi decrementado 1 para se encaixar no padrão do sistema.

# Setup

- [ ] Aponte para o backend de staging
- [ ] `yarn start`

# Cenários

## 1. Cenário A**

- [ ] Acesse a conta `nabson.aluno@icomp.ufam.edu.br` | `12345678`
- [ ] Vá na tela de editar monitoria e verifique a disponibilidade cadastrada
- [ ] Acesse uma conta de aluno matriculado na disciplina Desafios De Programação I
- [ ] Tente agendar uma monitoria com Nabson Paiva
- [ ] Verifique se a disponibilidade está correta


